### PR TITLE
Save `year-month` Format

### DIFF
--- a/src/components/PromptCard.vue
+++ b/src/components/PromptCard.vue
@@ -3,8 +3,9 @@
     <q-card-section class="row items-center no-wrap">
       <h2 class="q-my-none text-h6">{{ id ? 'Edit Prompt' : 'New Prompt' }}</h2>
       <span>&nbsp; for &nbsp;</span>
+      <!-- TODO: apply closest years dinamically -->
       <q-select behavior="menu" borderless dense :options="[2021, 2022, 2023]" v-model="prompt.date.year" />
-      <q-select behavior="menu" borderless dense :options="months" v-model="prompt.date.month" />
+      <q-select behavior="menu" borderless dense :options="monthsOfTheYear" v-model="prompt.date.month" />
       <q-space />
       <q-btn flat round icon="close" v-close-popup />
     </q-card-section>
@@ -64,7 +65,9 @@
         <q-btn
           class="full-width q-mt-xl"
           color="primary"
-          :disable="!prompt.title || !prompt.description || !prompt.categories?.length || !prompt.image"
+          :disable="
+            !prompt.date.year || !prompt.date.month || !prompt.title || !prompt.description || !prompt.categories?.length || !prompt.image
+          "
           :label="id ? 'Edit' : 'Save'"
           rounded
           type="submit"
@@ -78,7 +81,7 @@
 <script setup>
 import { useQuasar } from 'quasar'
 import { usePromptStore } from 'src/stores'
-import { months, shortMonthDay } from 'src/utils/date'
+import { monthsOfTheYear, shortMonthDay } from 'src/utils/date'
 import { reactive, ref, watchEffect } from 'vue'
 
 const emit = defineEmits(['hideDialog'])
@@ -101,10 +104,10 @@ watchEffect(() => {
     prompt.title = props.title
   } else {
     prompt.categories = null
-    prompt.date = { year: new Date().getFullYear(), month: new Date().toLocaleString('en-US', { month: 'long' }) }
+    prompt.date = { year: new Date().getFullYear(), month: monthsOfTheYear[new Date().getMonth()] }
     prompt.description = ''
     prompt.image = ''
-    prompt.info = { comments: 0, dislikes: [], likes: [], shares: 0 }
+    prompt.info = { dislikes: [], likes: [], shares: 0 }
     prompt.title = ''
   }
 })

--- a/src/components/PromptCard.vue
+++ b/src/components/PromptCard.vue
@@ -2,6 +2,9 @@
   <q-card>
     <q-card-section class="row items-center no-wrap">
       <h2 class="q-my-none text-h6">{{ id ? 'Edit Prompt' : 'New Prompt' }}</h2>
+      <span>&nbsp; for &nbsp;</span>
+      <q-select behavior="menu" borderless dense :options="[2021, 2022, 2023]" v-model="prompt.date.year" />
+      <q-select behavior="menu" borderless dense :options="months" v-model="prompt.date.month" />
       <q-space />
       <q-btn flat round icon="close" v-close-popup />
     </q-card-section>
@@ -75,11 +78,11 @@
 <script setup>
 import { useQuasar } from 'quasar'
 import { usePromptStore } from 'src/stores'
-import { shortMonthDay } from 'src/utils/date'
+import { months, shortMonthDay } from 'src/utils/date'
 import { reactive, ref, watchEffect } from 'vue'
 
 const emit = defineEmits(['hideDialog'])
-const props = defineProps(['author', 'categories', 'created', 'description', 'id', 'image', 'info', 'slug', 'title'])
+const props = defineProps(['author', 'categories', 'created', 'date', 'description', 'id', 'image', 'info', 'slug', 'title'])
 
 const $q = useQuasar()
 const promptStore = usePromptStore()
@@ -91,12 +94,14 @@ const prompt = reactive({})
 watchEffect(() => {
   if (props.id) {
     prompt.categories = props.categories
+    prompt.date = props.date
     prompt.description = props.description
     prompt.id = props.id
     prompt.image = props.image
     prompt.title = props.title
   } else {
     prompt.categories = null
+    prompt.date = { year: new Date().getFullYear(), month: new Date().toLocaleString('en-US', { month: 'long' }) }
     prompt.description = ''
     prompt.image = ''
     prompt.info = { comments: 0, dislikes: [], likes: [], shares: 0 }

--- a/src/pages/AdminPage.vue
+++ b/src/pages/AdminPage.vue
@@ -14,7 +14,7 @@
         transition-hide="jump-up"
       >
         <q-list style="min-width: 100px">
-          <q-item clickable @click="prompt.dialog = true">
+          <q-item clickable @click="openPromptDialog()">
             <q-item-section>New Prompt</q-item-section>
           </q-item>
           <q-item clickable @click="entry.dialog = true">
@@ -36,7 +36,7 @@
         </template>
         <template v-slot:body-cell-actions="props">
           <q-td :props="props">
-            <q-btn color="warning" flat icon="edit" round size="sm" @click="prompt = props.row" />
+            <q-btn color="warning" flat icon="edit" round size="sm" @click="openPromptDialog(props.row)" />
             <q-btn color="negative" flat icon="delete" round size="sm" @click="onDeleteDialog(props.row)" />
           </q-td>
         </template>
@@ -84,21 +84,8 @@ const $q = useQuasar()
 const promptStore = usePromptStore()
 
 const columns = [
-  {
-    name: 'created',
-    label: 'Created at',
-    align: 'left',
-    field: (row) => shortMonthDay(row.created),
-    format: (val) => `${val}`,
-    sortable: true
-  },
-  {
-    name: 'author',
-    align: 'center',
-    label: 'Author',
-    field: (row) => row.author.displayName,
-    sortable: true
-  },
+  { name: 'date', align: 'center', label: 'Date', field: (row) => row.date, sortable: true, åsortable: true },
+  { name: 'author', align: 'center', label: 'Author', field: (row) => row.author.displayName, sortable: true },
   { name: 'title', align: 'left', label: 'Title', field: 'title', sortable: true },
   { name: 'actions', field: 'actions' }
 ]
@@ -114,6 +101,11 @@ onMounted(async () => {
   await promptStore.fetchPrompts()
   prompts.value = promptStore.getPrompts
 })
+
+function openPromptDialog(props) {
+  props?.id ? (prompt.value = props) : (prompt.value = {})
+  prompt.value.dialog = true
+}
 
 function onDeleteDialog(prompt) {
   deleteDialog.value.show = true

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -1,5 +1,4 @@
 import {
-  addDoc,
   arrayRemove,
   arrayUnion,
   collection,
@@ -11,6 +10,7 @@ import {
   orderBy,
   query,
   runTransaction,
+  setDoc,
   Timestamp,
   updateDoc
 } from 'firebase/firestore'
@@ -107,7 +107,7 @@ export const usePromptStore = defineStore('prompts', {
       prompt.created = Timestamp.fromDate(new Date())
 
       this._isLoading = true
-      await addDoc(collection(db, 'prompts'), prompt)
+      await setDoc(doc(db, 'prompts', `${prompt.date.year}-${prompt.date.month.value}`), prompt)
         .then(() => {
           this.$patch({ _prompts: [...this.getPrompts, prompt] })
           LocalStorage.set('prompts', this._prompts)

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -107,7 +107,7 @@ export const usePromptStore = defineStore('prompts', {
       prompt.created = Timestamp.fromDate(new Date())
 
       this._isLoading = true
-      await setDoc(doc(db, 'prompts', `${prompt.date.year}-${prompt.date.month.value}`), prompt)
+      await setDoc(doc(db, 'prompts', prompt.date), prompt)
         .then(() => {
           this.$patch({ _prompts: [...this.getPrompts, prompt] })
           LocalStorage.set('prompts', this._prompts)

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,18 +1,3 @@
-export const monthsOfTheYear = [
-  { label: 'January', value: 1 },
-  { label: 'February', value: 2 },
-  { label: 'March', value: 3 },
-  { label: 'April', value: 4 },
-  { label: 'May', value: 5 },
-  { label: 'June', value: 6 },
-  { label: 'July', value: 7 },
-  { label: 'August', value: 8 },
-  { label: 'September', value: 9 },
-  { label: 'October', value: 10 },
-  { label: 'November', value: 11 },
-  { label: 'December', value: 12 }
-]
-
 export function shortMonthDay(timestamp) {
   const date = timestamp ? new Date(timestamp.seconds * 1000 + timestamp.nanoseconds / 1000000) : new Date()
 

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,4 +1,4 @@
-export const months = [
+export const monthsOfTheYear = [
   { label: 'January', value: 1 },
   { label: 'February', value: 2 },
   { label: 'March', value: 3 },

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,13 +1,20 @@
-function shortMonthDay(timestamp = undefined) {
-  let date
+export const months = [
+  { label: 'January', value: 1 },
+  { label: 'February', value: 2 },
+  { label: 'March', value: 3 },
+  { label: 'April', value: 4 },
+  { label: 'May', value: 5 },
+  { label: 'June', value: 6 },
+  { label: 'July', value: 7 },
+  { label: 'August', value: 8 },
+  { label: 'September', value: 9 },
+  { label: 'October', value: 10 },
+  { label: 'November', value: 11 },
+  { label: 'December', value: 12 }
+]
 
-  if (timestamp) {
-    date = new Date(timestamp.seconds * 1000 + timestamp.nanoseconds / 1000000)
-  } else {
-    date = new Date()
-  }
+export function shortMonthDay(timestamp) {
+  const date = timestamp ? new Date(timestamp.seconds * 1000 + timestamp.nanoseconds / 1000000) : new Date()
 
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) // Nov 2
 }
-
-export { shortMonthDay }


### PR DESCRIPTION
Fix #35 

Now, when saving our prompts, the generated document has its id in the `year-month` format.