### PR TITLE
Changed UI layout for search page and user entries section

### DIFF
--- a/src/components/shared/ItemCard.vue
+++ b/src/components/shared/ItemCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="q-pt-md relative-position row">
+  <article class="q-pa-md relative-position row article-card-item">
     <div class="col-8 flex column">
       <router-link v-if="item.author" class="flex items-center link" :to="`/fan/${item.author.username || item.author.uid}`">
         <q-avatar size="2rem">
@@ -27,7 +27,6 @@
       <q-img :ratio="1" :src="item.image" style="border-radius: 24px" @click="goToUrl()" />
     </router-link>
     <!-- TODO: Add 'Selected for you' and two more buttons according to mockup -->
-    <q-separator class="full-width q-mt-md" />
   </article>
 </template>
 
@@ -61,5 +60,17 @@ function goToUrl() {
 .link {
   text-decoration: none;
   color: black;
+}
+
+.article-card-item {
+  min-width: 620px;
+  width: 100%;
+  border: 1px solid #e54757;
+  border-radius: 24px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+
+  @media (max-width: 1320px) {
+    min-width: 320px;
+  }
 }
 </style>

--- a/src/components/shared/ItemCard.vue
+++ b/src/components/shared/ItemCard.vue
@@ -63,14 +63,26 @@ function goToUrl() {
 }
 
 .article-card-item {
-  min-width: 620px;
+  min-width: 619px;
   width: 100%;
   border: 1px solid #e54757;
   border-radius: 24px;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
 
-  @media (max-width: 1320px) {
-    min-width: 320px;
+  @media (max-width: 1440px) {
+    min-width: 590px;
+  }
+
+  @media (min-width: 1024px) {
+    min-width: 470px;
+  }
+
+  @media (max-width: 768px) {
+    min-width: 361px;
+  }
+
+  @media (max-width: 425px) {
+    min-width: 280px;
   }
 }
 </style>

--- a/src/components/shared/TheEntries.vue
+++ b/src/components/shared/TheEntries.vue
@@ -1,5 +1,9 @@
-<template  >
-  <section class="bg-white q-mb-xl q-pa-md q-page-container entries-page-container" :data-test="props.entries ? 'entries' : ''" style="padding-bottom: 7rem;">
+<template>
+  <section
+    class="bg-white q-mb-xl q-pa-md q-page-container entries-page-container"
+    :data-test="props.entries ? 'entries' : ''"
+    style="padding-bottom: 7rem"
+  >
     <h2 class="q-my-auto text-bold text-h5 q-pa-md">Entries</h2>
     <div class="card-items-wrapper">
       <ItemCard v-for="entry in entries" :item="entry" :key="entry?.id" :link="entry.slug" data-test="entry" />
@@ -19,22 +23,32 @@ const entryStore = useEntryStore()
 </script>
 
 <style lang="scss" scoped>
-
 .entries-page-container {
   max-width: 100%;
 }
 
-.card-items-wrapper{
+.card-items-wrapper {
   display: grid;
   margin: 0;
   justify-items: center;
   row-gap: 16px;
   column-gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(620px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(619px, 1fr));
 
-  @media (max-width: 1320px) {
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  @media (max-width: 1440px) {
+    grid-template-columns: repeat(auto-fill, minmax(590px, 1fr));
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(auto-fill, minmax(470px, 1fr));
+  }
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(auto-fill, minmax(361px, 1fr));
+  }
+
+  @media (max-width: 425px) {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 }
-
 </style>

--- a/src/components/shared/TheEntries.vue
+++ b/src/components/shared/TheEntries.vue
@@ -1,8 +1,9 @@
-<template>
-  <section class="bg-white q-mb-xl q-pa-md q-page-container" :data-test="props.entries ? 'entries' : ''" style="padding-bottom: 7rem">
-    <h2 class="q-my-auto text-bold text-h5">Entries</h2>
-    <q-separator />
-    <ItemCard v-for="entry in entries" :item="entry" :key="entry?.id" :link="entry.slug" data-test="entry" />
+<template  >
+  <section class="bg-white q-mb-xl q-pa-md q-page-container entries-page-container" :data-test="props.entries ? 'entries' : ''" style="padding-bottom: 7rem;">
+    <h2 class="q-my-auto text-bold text-h5 q-pa-md">Entries</h2>
+    <div class="card-items-wrapper">
+      <ItemCard v-for="entry in entries" :item="entry" :key="entry?.id" :link="entry.slug" data-test="entry" />
+    </div>
     <q-spinner v-if="entryStore.isLoading" color="primary" size="3em" class="block q-mx-auto q-my-xl" />
     <h6 v-else-if="!entries?.length" class="text-center">NO ENTRIES</h6>
   </section>
@@ -16,3 +17,24 @@ const props = defineProps(['entries'])
 
 const entryStore = useEntryStore()
 </script>
+
+<style lang="scss" scoped>
+
+.entries-page-container {
+  max-width: 100%;
+}
+
+.card-items-wrapper{
+  display: grid;
+  margin: 0;
+  justify-items: center;
+  row-gap: 16px;
+  column-gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(620px, 1fr));
+
+  @media (max-width: 1320px) {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
+}
+
+</style>

--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -6,7 +6,7 @@
     :title="`${router.currentRoute.value.params.year} Search Archive`"
     v-model="search"
   />
-  <q-page-container>
+  <q-page-container class="search-page-container">
     <q-page class="q-pa-md">
       <q-scroll-area :thumb-style="{ display: 'none' }" style="height: 3.8rem">
         <q-btn-toggle
@@ -21,7 +21,6 @@
           unelevated
         />
       </q-scroll-area>
-      <q-separator class="q-mb-none q-mt-xs" />
       <section v-if="!promptStore.getPrompts && promptStore.isLoading">
         <ArticleSkeleton />
         <ArticleSkeleton />
@@ -30,7 +29,7 @@
       </section>
       <q-tab-panels animated swipeable v-model="category">
         <q-tab-panel v-for="(categ, i) in computedCategories" class="panel" :key="i" :name="categ.value">
-          <TransitionGroup name="prompt" tag="div">
+          <TransitionGroup name="prompt" tag="div" class="card-items-wrapper">
             <ItemCard
               v-for="prompt in computedPrompts"
               data-test="prompt-card"
@@ -118,5 +117,22 @@ const computedEntries = computed(() => {
   opacity: 0;
   height: 0;
   transform: translateY(-90px);
+}
+
+.search-page-container{
+  max-width: 100%;
+}
+
+.card-items-wrapper{
+  display: grid;
+  margin: 0;
+  justify-items: center;
+  row-gap: 16px;
+  column-gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(620px, 1fr));
+
+  @media (max-width: 1320px) {
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  }
 }
 </style>

--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -119,20 +119,32 @@ const computedEntries = computed(() => {
   transform: translateY(-90px);
 }
 
-.search-page-container{
+.search-page-container {
   max-width: 100%;
 }
 
-.card-items-wrapper{
+.card-items-wrapper {
   display: grid;
   margin: 0;
   justify-items: center;
   row-gap: 16px;
   column-gap: 16px;
-  grid-template-columns: repeat(auto-fill, minmax(620px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(619px, 1fr));
 
-  @media (max-width: 1320px) {
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  @media (max-width: 1440px) {
+    grid-template-columns: repeat(auto-fill, minmax(590px, 1fr));
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(auto-fill, minmax(470px, 1fr));
+  }
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  }
+
+  @media (max-width: 425px) {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   }
 }
 </style>


### PR DESCRIPTION
Changed ui layout for the search page and user entries section, to make it also a desktop version and more responsive.
![Screenshot 2024-03-23 at 17 30 12](https://github.com/globe-and-citizen/Celebrity-Fanalyzer/assets/43423591/284ace1d-7149-4521-8be3-e62355f887aa)
![Screenshot 2024-03-23 at 17 30 23](https://github.com/globe-and-citizen/Celebrity-Fanalyzer/assets/43423591/cc77e7d7-1de0-43ac-a362-ad1d7939c440)
