### PR TITLE
Fix/failure creating an entry for prompt 362

### DIFF
--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -62,7 +62,9 @@ export const useEntryStore = defineStore('entries', {
         const entries = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
 
         for (const entry of entries) {
-          entry.author = userStore.getUserById(entry.author.id) || (await userStore.fetchUser(entry.author.id))
+          if (entry.author.id) {
+            entry.author = userStore.getUserById(entry.author.id) || (await userStore.fetchUser(entry.author.id))
+          }
           entry.prompt = entry.prompt.id
         }
 


### PR DESCRIPTION
fix: creating an entry for prompt failure + no entries on admin page and for prompts.


![Screenshot 2024-04-16 at 13 23 41](https://github.com/globe-and-citizen/Celebrity-Fanalyzer/assets/43423591/1794617c-5d01-433a-969b-b879a776a036)
![Screenshot 2024-04-16 at 13 24 03](https://github.com/globe-and-citizen/Celebrity-Fanalyzer/assets/43423591/02f7af0c-bfca-4a95-b96d-bde63b95a479)
