### PR TITLE
Implemented ai comments analysis

### DIFF
--- a/src/components/Posts/TheComments.vue
+++ b/src/components/Posts/TheComments.vue
@@ -19,57 +19,69 @@
       </div>
 
       <q-form greedy @submit.prevent="commentStore.haveToReply ? addReply() : addComment()">
-        <q-input
-          class="bg-white fixed-bottom q-px-sm q-page-container z-fab"
-          :data-test="commentStore.haveToReply ? 'fill-add-reply' : 'comment-main-box'"
-          dense
-          :label="commentStore.haveToReply ? 'Reply' : 'Comment'"
-          lazy-rules
-          :name="commentStore.haveToReply ? commentId : ''"
-          ref="inputField"
-          :required="!commentStore.haveToReply"
-          rounded
-          standout="bg-secondary text-white"
-          style="margin-bottom: 7rem"
-          v-model="commentValue"
-          @blur="isMention = false"
-          @keydown.escape="inputField.blur()"
-        >
-          <q-list v-if="isMention" class="absolute bg-secondary rounded-borders text-caption" dark style="bottom: 40px">
-            <q-item v-for="(commenter, index) in commenters" clickable :key="index" @click="mentionUser(commenter)">
-              <q-item-section>{{ commenter.name }}</q-item-section>
-            </q-item>
-          </q-list>
-
-          <div v-if="commentStore.haveToReply" class="replyTop">
-            <p>
-              Replying to
-              <span class="text-bold">{{ getReplyAuthor() }}</span>
-            </p>
-            <q-btn dense flat icon="close" round size="sm" @click="commentStore.setReplyTo('')" />
-          </div>
-          <q-btn
-            color="grey-6"
-            :data-test="commentStore.haveToReply ? 'submit-fill-add-reply' : ''"
+        <div class="fixed-bottom q-px-sm q-page-container position-relative">
+          <q-input
+            class="bg-white z-fab"
+            :data-test="commentStore.haveToReply ? 'fill-add-reply' : 'comment-main-box'"
             dense
-            :disable="!commentValue"
-            flat
-            icon="send"
-            round
-            type="submit"
+            :label="commentStore.haveToReply ? 'Reply' : 'Comment'"
+            lazy-rules
+            :name="commentStore.haveToReply ? commentId : ''"
+            ref="inputField"
+            :required="!commentStore.haveToReply"
+            rounded
+            standout="bg-secondary text-white"
+            style="margin-bottom: 7rem"
+            v-model="commentValue"
+            @blur="isMention = false"
+            @keydown.escape="inputField.blur()"
+          >
+            <q-list v-if="isMention" class="absolute bg-secondary rounded-borders text-caption" dark style="bottom: 40px">
+              <q-item v-for="(commenter, index) in commenters" clickable :key="index" @click="mentionUser(commenter)">
+                <q-item-section>{{ commenter.name }}</q-item-section>
+              </q-item>
+            </q-list>
+
+            <div v-if="commentStore.haveToReply" class="replyTop">
+              <p>
+                Replying to
+                <span class="text-bold">{{ getReplyAuthor() }}</span>
+              </p>
+              <q-btn dense flat icon="close" round size="sm" @click="commentStore.setReplyTo('')" />
+            </div>
+            <q-btn
+              color="grey-6"
+              :data-test="commentStore.haveToReply ? 'submit-fill-add-reply' : ''"
+              dense
+              :disable="!commentValue"
+              flat
+              icon="send"
+              round
+              type="submit"
+            />
+          </q-input>
+          <q-btn
+            v-if="commentStore.getComments?.length >= 10"
+            class="analysis-btn"
+            :loading="statsStore.isLoading"
+            :disable="statsStore.isLoading"
+            color="primary"
+            @click="analyzeComments"
+            @click.stop.prevent
+            label="Sentiment analysis"
           />
-        </q-input>
+        </div>
       </q-form>
     </q-page>
   </q-page-container>
 </template>
 
 <script setup>
-import { useQuasar } from 'quasar'
+import { Notify, useQuasar } from 'quasar'
 import DisplayComment from 'src/components/Posts/Comments/DisplayComment.vue'
 import TheHeader from 'src/components/shared/TheHeader.vue'
-import { useCommentStore, useErrorStore, useNotificationStore, useUserStore } from 'src/stores'
-import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watchEffect } from 'vue'
+import { useCommentStore, useErrorStore, useNotificationStore, useStatStore, useUserStore } from 'src/stores'
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch, watchEffect } from 'vue'
 
 const props = defineProps({
   collectionName: { type: String, required: true },
@@ -81,12 +93,14 @@ const commentStore = useCommentStore()
 const errorStore = useErrorStore()
 const notificationStore = useNotificationStore()
 const userStore = useUserStore()
+const statsStore = useStatStore()
 
 const commentId = ref('')
 const commentValue = ref('')
 const inputField = ref()
 const isMention = ref(false)
 const mentionedUsers = ref([])
+const commentsMessages = ref([])
 const reply = reactive({})
 const comments = computed(() => {
   return commentStore.getComments?.filter((comment) => !comment.parentId && comment.author)
@@ -96,6 +110,10 @@ const commenters = computed(() => {
   return commentStore.getComments
     .map((comment) => ({ id: comment.author?.uid, name: comment.author?.displayName }))
     .filter((value, index, self) => value.id && value.name && self.findIndex((t) => t.id === value.id && t.name === value.name) === index)
+})
+
+watch(comments, () => {
+  commentsMessages.value = comments.value?.map((comment) => comment.text)
 })
 
 watchEffect(() => {
@@ -155,6 +173,25 @@ async function addComment() {
     })
 }
 
+async function analyzeComments() {
+  await statsStore.getCommentsAnalysis(props.post?.id, commentsMessages.value).then(() => {
+    Notify.create({
+      message: `Users comments analyzed. Overall users' sentiment based on their comments is: ${statsStore.getSentiment}`,
+      color: 'primary',
+      multiLine: true,
+      timeout: 0,
+      avatar: 'https://cdn.quasar.dev/img/boy-avatar.png',
+      actions: [
+        {
+          label: 'Close',
+          color: 'yellow',
+          handler: () => {}
+        }
+      ]
+    })
+  })
+}
+
 watchEffect(async () => {
   await commentStore.fetchComments(props.collectionName, props.post.id)
 })
@@ -210,5 +247,20 @@ onMounted(async () => {
   position: absolute;
   top: -30px;
   width: 100%;
+}
+.analysis-btn {
+  position: absolute;
+  bottom: 115px;
+  right: -180px;
+
+  @media (max-width: 1024px) {
+    bottom: 160px;
+    right: 10px;
+  }
+
+  @media (max-width: 425px) {
+    bottom: 145px;
+    right: 10px;
+  }
 }
 </style>

--- a/src/stores/stats.js
+++ b/src/stores/stats.js
@@ -10,7 +10,8 @@ export const useStatStore = defineStore('stats', {
     _stats: [],
     _summary: [],
     _allInteractionsByCountry: [],
-    _articleRating: []
+    _articleRating: [],
+    _sentiment: ''
   }),
 
   getters: {
@@ -18,7 +19,8 @@ export const useStatStore = defineStore('stats', {
     getStats: (state) => state._stats,
     getSummary: (state) => state._summary,
     getAllInteractionsByCountry: (state) => state._allInteractionsByCountry,
-    getArticleRate: (state) => state._articleRating
+    getArticleRate: (state) => state._articleRating,
+    getSentiment: (state) => state._sentiment
   },
 
   actions: {
@@ -172,6 +174,26 @@ export const useStatStore = defineStore('stats', {
         const data = await res.json()
         this._articleRating = data
         return data
+      } catch (err) {
+        console.log(err)
+        return null
+      }
+    },
+
+    async getCommentsAnalysis(id, comments) {
+      this._isLoading = true
+      try {
+        const res = await layer8.fetch(`${baseURL}/comments/analyze`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ id, comments })
+        })
+        const sentiment = await res.json()
+        this._sentiment = sentiment.response
+        this._isLoading = false
+        return sentiment
       } catch (err) {
         console.log(err)
         return null


### PR DESCRIPTION
Implemented comments analysis using openAi api. 
Created an "Analyze sentimen" button. When clicked the request is sent to stats-api where we check if it exists in cache, if so return cached sentiment, otherwise we send an request to OpenAi to analyze users' sentiment based on comments and return + save in cache the result. 

Analyze button appears only if there are 10 or more comments! This way we reduce unnecessary calls to API. 

https://vimeo.com/961331486?share=copy

![Screenshot 2024-06-18 at 18 55 16](https://github.com/globe-and-citizen/Celebrity-Fanalyzer/assets/43423591/db15aa73-98b3-43e5-8427-4c6b32a9050e)
![Screenshot 2024-06-18 at 18 17 27](https://github.com/globe-and-citizen/Celebrity-Fanalyzer/assets/43423591/864a505d-2967-4d0b-b043-48546f02b07f)

