### PR TITLE
Feat/cloudflare trace optimization

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,13 @@
 <template>
-  <div v-if="statsStore.getInitializedState">
+  <div>
     <router-view />
-  </div>
-  <div class="flex" v-else>
-    Establishing encrypted tunnel...
-    <q-spinner class="q-mx-auto" color="primary" size="3em" style="width: 50%" />
   </div>
 </template>
 
 <script setup>
 import { onMounted } from 'vue'
-import { useStatStore } from 'src/stores'
-import layer8 from 'layer8_interceptor'
+import { Layer8Init } from 'src/utils/layer8Init'
 
-const statsStore = useStatStore()
 const asciiLogo = `
 @@@@@@@@@@@@@@@@@@@(((@@@@@@@@@@@@@@@@@@
 @@@@@@@@@@@(((((((((((((((((((@@@@@@@@@@s
@@ -35,20 +29,9 @@ const asciiLogo = `
 Don't hack us, contribute with us:
 https://github.com/globe-and-citizen/Celebrity-Fanalyzer`
 
-onMounted(async () => {
-  try {
-    await layer8.initEncryptedTunnel(
-      {
-        providers: ['https://stats-api.up.railway.app/v1'],
-        proxy: 'https://layer8proxy.net'
-      },
-      'dev'
-    )
-    statsStore.setInitialized(true)
-  } catch (err) {
-    console.log('.initEncryptedTunnel error: ', err)
-  }
-})
-
 console.log(asciiLogo)
+
+onMounted(async () => {
+  await Layer8Init()
+})
 </script>

--- a/src/components/Advertiser/CampaignCard.vue
+++ b/src/components/Advertiser/CampaignCard.vue
@@ -71,8 +71,6 @@ onMounted(async () => {
   })
   observer.observe(articleRef.value)
 
-  await userStore.fetchUserIp()
-
   visitorStore.readVisitors('advertises', props.advertise.id).catch((error) => errorStore.throwError(error))
 
   await visitorStore.addVisitor('advertises', props.advertise.id).catch((error) => errorStore.throwError(error))

--- a/src/components/Posts/Comments/DisplayComment.vue
+++ b/src/components/Posts/Comments/DisplayComment.vue
@@ -184,9 +184,7 @@ const reportOptions = [
 
 const $q = useQuasar()
 onMounted(async () => {
-  await userStore.fetchUserIp()
   userId.value = userStore.isAuthenticated ? userStore.getUserRef?.id : userStore.getUserIpHash
-
   window.addEventListener('keydown', handleKeydown)
 })
 

--- a/src/components/Posts/ThePost.vue
+++ b/src/components/Posts/ThePost.vue
@@ -178,11 +178,10 @@ const userRating = ref(0)
 
 onMounted(async () => {
   // =========== STATS ===========
-  await userStore.fetchUserIp()
   const userId = userStore.getUserId ? userStore.getUserId : userStore.getUserIpHash
   const userLocation = userStore.getUserLocation
   await statsStore.addUser(userId, userLocation)
-  if (typeof props.post.entries !== 'undefined') {
+  if (typeof props.post?.entries !== 'undefined') {
     await statsStore.addTopic(props.post?.id, props.post.author?.uid, props.post?.title, props.post?.description, props.post?.categories)
   }
   if (typeof props.post.prompt !== 'undefined') {

--- a/src/layouts/MainMenu.vue
+++ b/src/layouts/MainMenu.vue
@@ -94,6 +94,10 @@ watchEffect(async () => {
 })
 
 onMounted(async () => {
+  if (!userStore.getUserIp.length) {
+    await userStore.fetchUserIp()
+  }
+  console.log(userStore.getUserIp)
   if (params.year && params.month && !params.id) {
     promptStore.fetchPromptBySlug(`${params.year}-${params.month}`).catch((error) => errorStore.throwError(error))
   }

--- a/src/layouts/MainMenu.vue
+++ b/src/layouts/MainMenu.vue
@@ -97,7 +97,6 @@ onMounted(async () => {
   if (!userStore.getUserIp.length) {
     await userStore.fetchUserIp()
   }
-  console.log(userStore.getUserIp)
   if (params.year && params.month && !params.id) {
     promptStore.fetchPromptBySlug(`${params.year}-${params.month}`).catch((error) => errorStore.throwError(error))
   }

--- a/src/pages/PromptPage.vue
+++ b/src/pages/PromptPage.vue
@@ -33,10 +33,8 @@ import { useCommentStore, useEntryStore, useErrorStore, useLikeStore, usePromptS
 import { currentYearMonth } from 'src/utils/date'
 import { computed, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { onBeforeRouteLeave, useRouter } from 'vue-router'
-import { useQuasar } from 'quasar'
 
 const router = useRouter()
-const $q = useQuasar()
 const commentStore = useCommentStore()
 const entryStore = useEntryStore()
 const errorStore = useErrorStore()
@@ -51,7 +49,7 @@ const tab = ref(promptStore.tab)
 const shareIsLoading = ref(false)
 const shareIsLoaded = ref(false)
 
-const { href, params, path, name } = router.currentRoute.value
+const { params, name } = router.currentRoute.value
 const prompt = computed(() => {
   // eslint-disable-next-line vue/no-side-effects-in-computed-properties
   return promptStore.getPrompts

--- a/src/stores/clicks.js
+++ b/src/stores/clicks.js
@@ -1,7 +1,6 @@
 import { collection, deleteDoc, doc, getDoc, getDocs, onSnapshot, setDoc, updateDoc } from 'firebase/firestore'
 import { defineStore } from 'pinia'
 import { db } from 'src/firebase'
-import { useUserStore } from 'src/stores'
 import { monthDayYear } from 'src/utils/date'
 
 export const useClicksStore = defineStore('clicks', {
@@ -19,9 +18,6 @@ export const useClicksStore = defineStore('clicks', {
 
   actions: {
     async addClick(collectionName, documentId) {
-      const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const visitorRef = doc(db, collectionName, documentId, 'clicks', monthDayYear().replaceAll('/', '-'))
       const visitorSnap = await getDoc(visitorRef)
 
@@ -40,8 +36,7 @@ export const useClicksStore = defineStore('clicks', {
 
     async readClicks(collectionName, documentId) {
       onSnapshot(collection(db, collectionName, documentId, 'clicks'), (querySnapshot) => {
-        const clicks = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
-        this._clicks = clicks
+        this._clicks = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
       })
     },
 

--- a/src/stores/comments.js
+++ b/src/stores/comments.js
@@ -14,7 +14,6 @@ import {
   query,
   where,
   or,
-  and,
   orderBy
 } from 'firebase/firestore'
 import { defineStore } from 'pinia'
@@ -145,7 +144,6 @@ export const useCommentStore = defineStore('comments', {
 
     async addComment(collectionName, comment, document, isTest = false) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
       const user_id = userStore.getUserId ? userStore.getUserId : userStore.getUserIpHash
 
       comment.author = userStore.isAuthenticated ? userStore.getUserRef : userStore.getUserIpHash
@@ -162,9 +160,6 @@ export const useCommentStore = defineStore('comments', {
     },
 
     async editComment(collectionName, documentId, id, editedComment, userId) {
-      const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const comment = this.getComments?.find((comment) => comment.id === id)
       const index = this._comments.findIndex((comment) => comment.id === id)
 
@@ -191,8 +186,6 @@ export const useCommentStore = defineStore('comments', {
 
     async likeComment(collectionName, documentId, commentId) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const comment = this._comments.find((comment) => comment.id === commentId)
       const commentRef = doc(db, collectionName, documentId, 'comments', commentId)
       const user = userStore.isAuthenticated ? userStore.getUserRef : userStore.getUserIpHash
@@ -215,8 +208,6 @@ export const useCommentStore = defineStore('comments', {
 
     async dislikeComment(collectionName, documentId, commentId) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const comment = this._comments.find((comment) => comment.id === commentId)
       const commentRef = doc(db, collectionName, documentId, 'comments', commentId)
       const user = userStore.isAuthenticated ? userStore.getUserRef : userStore.getUserIpHash
@@ -239,8 +230,6 @@ export const useCommentStore = defineStore('comments', {
 
     async deleteComment(collectionName, documentId, commentId) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       this._isLoading = true
       await runTransaction(db, async (transaction) => {
         const relatedCommentsQuery = query(collection(db, collectionName, documentId, 'comments'), where('parentId', '==', commentId))
@@ -276,8 +265,6 @@ export const useCommentStore = defineStore('comments', {
 
     async addReply(collectionName, documentId, reply) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       reply.author = userStore.getUserRef || userStore.getUserIpHash
       reply.created = Timestamp.fromDate(new Date())
       reply.id ??= Date.now() + '-' + (reply.author.id || reply.author)
@@ -289,9 +276,6 @@ export const useCommentStore = defineStore('comments', {
     },
 
     async removeCommentFromFirestore(collectionName, documentId, commentId) {
-      const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       this._isLoading = true
       await deleteDoc(doc(db, collectionName, documentId, 'comments', commentId)).finally(() => (this._isLoading = false))
     },

--- a/src/stores/errors.js
+++ b/src/stores/errors.js
@@ -36,8 +36,6 @@ export const useErrorStore = defineStore('errors', {
 
     async throwError(error, message) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const err = {
         createdAt: Timestamp.fromDate(new Date()),
         error: error.stack,

--- a/src/stores/impressions.js
+++ b/src/stores/impressions.js
@@ -1,7 +1,6 @@
 import { collection, deleteDoc, doc, getDoc, getDocs, onSnapshot, setDoc, updateDoc } from 'firebase/firestore'
 import { defineStore } from 'pinia'
 import { db } from 'src/firebase'
-import { useUserStore } from 'src/stores'
 import { monthDayYear } from 'src/utils/date'
 
 export const useImpressionsStore = defineStore('impressions', {
@@ -19,9 +18,6 @@ export const useImpressionsStore = defineStore('impressions', {
 
   actions: {
     async addImpression(collectionName, documentId) {
-      const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const visitorRef = doc(db, collectionName, documentId, 'impressions', monthDayYear().replaceAll('/', '-'))
       const visitorSnap = await getDoc(visitorRef)
 
@@ -40,8 +36,7 @@ export const useImpressionsStore = defineStore('impressions', {
 
     async readImpressions(collectionName, documentId) {
       onSnapshot(collection(db, collectionName, documentId, 'impressions'), (querySnapshot) => {
-        const impressions = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
-        this._impressions = impressions
+        this._impressions = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
       })
     },
 

--- a/src/stores/likes.js
+++ b/src/stores/likes.js
@@ -97,7 +97,6 @@ export const useLikeStore = defineStore('likes', {
       try {
         this._isLoading = true
         const userStore = useUserStore()
-        await userStore.fetchUserIp()
         const user_id = userStore.getUserId ? userStore.getUserId : userStore.getUserIpHash
 
         const dislikesRef = doc(db, collectionName, documentId, 'dislikes', userStore.getUserId)

--- a/src/stores/shares.js
+++ b/src/stores/shares.js
@@ -60,8 +60,6 @@ export const useShareStore = defineStore('shares', {
       try {
         this._isLoading = true
         const userStore = useUserStore()
-        await userStore.fetchUserIp()
-
         const user_id = userStore.getUserId ? userStore.getUserId : userStore.getUserIpHash
         const docId = socialNetwork + '-' + (userStore.isAuthenticated ? userStore.getUserRef.id : userStore.getUserIpHash)
 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -109,6 +109,8 @@ export const useUserStore = defineStore('user', {
      * @SaveState <string> IPV6
      */
     async fetchUserIp() {
+      this._userIp = ''
+      this._userLocation = ''
       await fetch('https://www.cloudflare.com/cdn-cgi/trace')
         .then((res) => res.text())
         .then((text) => {

--- a/src/stores/visitors.js
+++ b/src/stores/visitors.js
@@ -20,8 +20,6 @@ export const useVisitorStore = defineStore('visitors', {
   actions: {
     async addVisitor(collectionName, documentId) {
       const userStore = useUserStore()
-      await userStore.fetchUserIp()
-
       const visitorId = userStore.isAuthenticated ? userStore.getUserRef.id : userStore.getUserIp
 
       const visitorRef = doc(db, collectionName, documentId, 'visitors', visitorId)
@@ -42,8 +40,7 @@ export const useVisitorStore = defineStore('visitors', {
 
     async readVisitors(collectionName, documentId) {
       onSnapshot(collection(db, collectionName, documentId, 'visitors'), (querySnapshot) => {
-        const visitors = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
-        this._visitors = visitors
+        this._visitors = querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))
       })
     },
 

--- a/src/utils/layer8Init.js
+++ b/src/utils/layer8Init.js
@@ -1,0 +1,20 @@
+import layer8 from 'layer8_interceptor'
+import { useStatStore } from 'src/stores'
+import { useQuasar } from 'quasar'
+export async function Layer8Init() {
+  const $q = useQuasar()
+  const statsStore = useStatStore()
+  try {
+    await layer8.initEncryptedTunnel(
+      {
+        providers: ['https://stats-api.up.railway.app/v1'],
+        proxy: 'https://layer8proxy.net'
+      },
+      'dev'
+    )
+    statsStore.setInitialized(true)
+  } catch (err) {
+    $q.notify({ type: 'negative', message: `Encrypted Tunnel establishing error` })
+    console.log('.initEncryptedTunnel error: ', err)
+  }
+}


### PR DESCRIPTION
Refactored cloudflare trace request to be called only once instead of being called in each component. 
First we check if user ip and location are empty, we make a request to fetch data and store it in User Store and use stored that in all the components that need user IP.

Cleaned up unused imports, replaced some redundant variables with inline returns. 

Removed establishnc encrypted tunnel text from the initial loading of the App. Separated Layer8 initialization function. Added notification on failed connection. 