### PR TITLE
Bug/correct manual test issues

### DIFF
--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -324,7 +324,11 @@ async function onSubmit() {
         //save advertisement to database
         await advertiseStore
           .addAdvertise(advertise)
-          .then(() => $q.notify({ type: 'positive', message: 'Advertise successfully submitted' }))
+          .then(() => {
+            $q.notify({ type: 'positive', message: 'Advertise successfully submitted' })
+            $q.loading.hide()
+            emit('hideDialog')
+          })
           .catch((error) => {
             console.log(error)
             errorStore.throwError(error, 'Advertise submission failed')
@@ -334,14 +338,16 @@ async function onSubmit() {
         $q.loading.hide()
       }
     }
+    emit('hideDialog')
   } catch (error) {
     $q.notify({ message: 'Advertise submission failed', type: 'negative' })
     errorStore.throwError(error, 'Advertise submission failed')
+    emit('hideDialog')
+    $q.loading.hide()
   }
   // }else{
   //   $q.notify({ message: "please connect your blockchain wallet", type: 'negative' })
   // }
-  //emit('hideDialog')
-  $q.loading.hide()
+  emit('hideDialog')
 }
 </script>

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -83,7 +83,7 @@
               v-model="usdAmount"
               label="Price in USD"
               min="0"
-              mask="#.##"
+              mask="#.####"
               fill-mask="0"
               reverse-fill-mask
               @update:model-value="convertToMatic()"

--- a/src/web3/adCampaignManager.js
+++ b/src/web3/adCampaignManager.js
@@ -30,6 +30,8 @@ const getProvider = async () => {
     }
   } catch (error) {
     console.error('Error getting provider:', error)
+    const errorMessage = 'please connect your wallet'
+    error = 'please connect your wallet'
     throw error // Rethrow the error to handle it where getProvider is called
   }
 }
@@ -72,7 +74,11 @@ export const contractCreateAdCampaign = async (payload = { budgetInMatic: 0 }) =
       return { status: 'success', events }
     } catch (error) {
       console.error('Error creating ad campaign:', error)
-      return { status: 'error', error: error.data }
+      const errorData = { message: error.data.message }
+      if (errorData.message.includes('insufficient funds for gas')) {
+        errorData.message = 'insufficient funds for gas'
+      }
+      return { status: 'error', error: errorData }
     }
   } else {
     const errorMessage = 'Make sure the budget is greater than zero'
@@ -272,8 +278,8 @@ export const getEventsForCampaign = async (campaignCode) => {
       //console.log('Events retrieved successfully')
       return { status: 'success', events: result }
     } catch (error) {
-      console.error('Error retrieving events:', error)
-      return { status: 'error', error: error.error ? error.error.data : error }
+      const errorMessage = error.error ? error.error.data : error
+      return { status: 'error', error: { message: errorMessage } }
     }
   } else {
     const errorMessage = 'Make sure the campaignCode is not an empty string'


### PR DESCRIPTION
Based on marc suggestions after test.
When signing in and having no wallet connected, and when clicking “view events!” in the admin panel - advertises we get an ugly “missing provider (argument="provider", value=undefined, code=INVALID_ARGUMENT, version=providers/5.7.2)” error. I would suggest changing it to be more descriptive. 
After connecting the wallet and going back to advertises and clicking the same view events, it returns status success but then “Cannot read properties of undefined (reading 'eventRows’)” and loading spinner which can’t be closed. 
When navigating to prompts and entries to select the winner:
	1. If we have a selected winner already I would hide “select winner” toggle for the rest of the entries
		2. If the selected winner is treated (paid) I would suggest hiding the “select winner” toggle. 
		3. If the selected winner is treated (payed), I would suggest changing the “proceed payment” button to be something like “View transaction”
		4. If the selected winner is selected and treated I would suggest disabling the possibility to remove or edit the entry / prompt
		5. When selecting a winner UI should be automatically updated without the need of the refreshing the page 