### PR TITLE
Fixed new entry not showing + additional changes, fixes

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -193,7 +193,7 @@ async function onSubmit() {
     }
     if (href.includes('/admin') && !userStore.isEditorOrAbove) {
       await entryStore.fetchUserRelatedEntries(userStore.getUserId)
-    } else if (userStore.isEditorOrAbove && href.includes('/admin')) {
+    } else {
       const updatedPrompt = await promptStore.fetchPromptById(entry.prompt.value)
       const updatedList = updatedPrompt.find((prompt) => prompt.id === entry.prompt.value).entries
       const res = await entryStore.fetchPromptsEntries(updatedList)

--- a/src/pages/CampaignPage.vue
+++ b/src/pages/CampaignPage.vue
@@ -25,7 +25,6 @@ import TheAnthrogram from 'src/components/Posts/TheAnthrogram.vue'
 import TheComments from 'src/components/Posts/TheComments.vue'
 import ThePost from '../components/Posts/ThePost.vue'
 import {
-  useCommentStore,
   useErrorStore,
   useLikeStore,
   useAdvertiseStore,
@@ -42,7 +41,6 @@ import { startTracking, stopTracking } from 'src/utils/activityTracker'
 const router = useRouter()
 
 const $q = useQuasar()
-const commentStore = useCommentStore()
 const errorStore = useErrorStore()
 const likeStore = useLikeStore()
 const advertiseStore = useAdvertiseStore()
@@ -126,11 +124,7 @@ onUnmounted(async () => {
     await statStore.addStats(advertise.value?.id, stats, 'advertisement')
   }
   advertiseStore.setTab('post')
-  await likeStore.resetLikes()
-  await shareStore.resetShares()
-  await commentStore.resetComments()
-  await impressionStore.resetImpressions()
-  await likeStore.resetLikes()
+  await statStore.resetPostImpressions()
 })
 </script>
 

--- a/src/pages/EntryPage.vue
+++ b/src/pages/EntryPage.vue
@@ -22,7 +22,6 @@
 </template>
 
 <script setup>
-import { useQuasar } from 'quasar'
 import TheAnthrogram from 'src/components/Posts/TheAnthrogram.vue'
 import TheComments from 'src/components/Posts/TheComments.vue'
 import ThePost from 'src/components/Posts/ThePost.vue'
@@ -33,7 +32,6 @@ import { onBeforeRouteLeave, useRouter } from 'vue-router'
 
 const router = useRouter()
 
-const $q = useQuasar()
 const entryStore = useEntryStore()
 const errorStore = useErrorStore()
 const likeStore = useLikeStore()

--- a/src/pages/PromptPage.vue
+++ b/src/pages/PromptPage.vue
@@ -29,13 +29,12 @@ import TheComments from 'src/components/Posts/TheComments.vue'
 import ThePost from 'src/components/Posts/ThePost.vue'
 import TheEntries from 'src/components/shared/TheEntries.vue'
 import { startTracking, stopTracking } from 'src/utils/activityTracker'
-import { useCommentStore, useEntryStore, useErrorStore, useLikeStore, usePromptStore, useShareStore, useStatStore } from 'src/stores'
+import { useEntryStore, useErrorStore, useLikeStore, usePromptStore, useShareStore, useStatStore } from 'src/stores'
 import { currentYearMonth } from 'src/utils/date'
 import { computed, onMounted, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { onBeforeRouteLeave, useRouter, useRoute } from 'vue-router'
 
 const router = useRouter()
-const commentStore = useCommentStore()
 const entryStore = useEntryStore()
 const errorStore = useErrorStore()
 const likeStore = useLikeStore()
@@ -121,17 +120,14 @@ watch(entriesRef, (newVal) => {
 })
 
 onBeforeRouteLeave(async () => {
-  await statStore.resetStats()
-  await statStore.resetUserRating()
-})
-
-onUnmounted(async () => {
   const stats = stopTracking()
   await statStore.addStats(prompt.value?.id, stats, 'topic')
-  promptStore.setTab('post')
-  await likeStore.resetLikes()
-  await shareStore.resetShares()
-  await commentStore.resetComments()
+  statStore.resetStats()
+  statStore.resetUserRating()
+})
+
+onUnmounted(() => {
+  statStore.resetPostImpressions()
   window.removeEventListener('scroll', onScroll)
 })
 </script>

--- a/src/stores/advertises.js
+++ b/src/stores/advertises.js
@@ -198,9 +198,6 @@ export const useAdvertiseStore = defineStore('advertises', {
 
       this._isLoading = false
     },
-    resetAdvertises() {
-      this._advertises = []
-    },
     setTab(tab) {
       this.$patch({ _tab: tab })
     }

--- a/src/stores/clicks.js
+++ b/src/stores/clicks.js
@@ -50,10 +50,6 @@ export const useClicksStore = defineStore('clicks', {
         await deleteDoc(doc.ref)
       })
       this._isLoading = false
-    },
-    async resetClicks() {
-      this._likes = undefined
-      this._dislikes = undefined
     }
   }
 })

--- a/src/stores/impressions.js
+++ b/src/stores/impressions.js
@@ -50,10 +50,6 @@ export const useImpressionsStore = defineStore('impressions', {
         await deleteDoc(doc.ref)
       })
       this._isLoading = false
-    },
-    async resetImpressions() {
-      this._likes = undefined
-      this._dislikes = undefined
     }
   }
 })

--- a/src/stores/likes.js
+++ b/src/stores/likes.js
@@ -149,11 +149,6 @@ export const useLikeStore = defineStore('likes', {
         await deleteDoc(doc.ref)
       })
       this._isLoading = false
-    },
-
-    async resetLikes() {
-      this._likes = undefined
-      this._dislikes = undefined
     }
   }
 })

--- a/src/stores/shares.js
+++ b/src/stores/shares.js
@@ -92,10 +92,6 @@ export const useShareStore = defineStore('shares', {
       })
       await Promise.all(promises)
       this._isLoading = false
-    },
-
-    async resetShares() {
-      this._sharesCount = undefined
     }
   }
 })

--- a/src/stores/stats.js
+++ b/src/stores/stats.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { useUserStore } from 'src/stores'
+import { useClicksStore, useCommentStore, useImpressionsStore, useLikeStore, useShareStore, useUserStore } from 'src/stores'
 import layer8 from 'layer8_interceptor'
 
 export const baseURL = 'https://stats-api.up.railway.app/v1'
@@ -232,6 +232,26 @@ export const useStatStore = defineStore('stats', {
         console.log(err)
         return null
       }
+    },
+
+    // Reset comments, likes, shares, impressions, clicks for the posts
+    async resetPostImpressions() {
+      const commentsStore = useCommentStore()
+      const likesStore = useLikeStore()
+      const sharesStore = useShareStore()
+      const impressionsStore = useImpressionsStore()
+      const clicksStore = useClicksStore()
+
+      commentsStore._comments = undefined
+      likesStore._likes = undefined
+      likesStore._dislikes = undefined
+      sharesStore._sharesCount = undefined
+      impressionsStore._likes = undefined
+      impressionsStore._dislikes = undefined
+      clicksStore._clicks = undefined
+      this._stats = []
+      this._allInteractionsByCountry = []
+      this._articleRating = undefined
     }
   }
 })


### PR DESCRIPTION
- Fixed new entry not showing when adding from prompt page. 

- Additionally fixed the "Update stats" function that was throwing an error for some reason. It might be related to some other changes that update prompt data. Moved iadd stats function to onBeforeRouteLeave to update stats for a prompt. 

- Additionally removed unused import and code that came across. 

- Changed the reset process for posts' interactions (likes, shares, etc). Instead of having reset function in each of the stores and calling them separately, I moved them all to stats store and implemented a function to reset all the interactions from all other stores. This way we reduce some line of code from our component and make it more readable. 

https://github.com/user-attachments/assets/95efae08-970e-4677-a00b-94f2c1a1dbee

