### PR TITLE
Hid feedback button for unauthenticated user.

### DIFF
--- a/src/components/shared/TheHeader.vue
+++ b/src/components/shared/TheHeader.vue
@@ -15,7 +15,7 @@
       </q-toolbar-title>
       <NotificationBubble v-if="notificationButton && userStore.isAuthenticated" />
       <q-btn
-        v-if="feedbackButton"
+        v-if="feedbackButton && userStore.isAuthenticated"
         color="secondary"
         data-test="feedback-button"
         flat


### PR DESCRIPTION
Whenever I click on the feedback button it takes me to the login page, so if the user is not logged in the user should not be able to give feedback, so I hide the feedback button for unauthenticated users.