### PR TITLE
Fixed issue - Display of the missing role field.

### DIFF
--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -60,7 +60,7 @@ export const useUserStore = defineStore('user', {
 
     async fetchUsers() {
       this._isLoading = true
-      onSnapshot(query(collection(db, 'users'), where('role', '!=', 'User')), (querySnapshot) => {
+      onSnapshot(query(collection(db, 'users')), (querySnapshot) => {
         const users = querySnapshot.docs.map((doc) => ({ uid: doc.id, ...doc.data() }))
         this.$patch({ _users: users })
       })
@@ -155,7 +155,7 @@ export const useUserStore = defineStore('user', {
           const { email, displayName, photoURL, uid } = result.user
 
           if (isNewUser) {
-            await setDoc(doc(db, 'users', uid), { email, displayName, photoURL })
+            await setDoc(doc(db, 'users', uid), { email, displayName, photoURL, role: 'User' })
           }
 
           onSnapshot(doc(db, 'users', result.user.uid), (doc) => {


### PR DESCRIPTION
Fixed: If you search for a user in the Admin Panel’s USERS tab and they don’t have a role field defined in the database, they won’t be displayed.
