### PR TITLE
Visible indications for users to know the image is required #476

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -65,7 +65,7 @@
           counter
           data-test="file-image"
           :disable="!entry.prompt"
-          :hint="!entry.prompt ? 'Select prompt first' : 'Max size is 2MB'"
+          :hint="!entry.prompt ? 'Select prompt first' : '*Image is required. Max size is 2MB.'"
           label="Image"
           :max-total-size="2097152"
           :required="!id"
@@ -89,7 +89,23 @@
           :loading="promptStore.isLoading || storageStore.isLoading"
           rounded
           type="submit"
-        />
+        >
+          <q-tooltip
+            v-if="!entry.title || !entry.description || !entry.prompt || !entry.image"
+            class="text-center"
+            style="white-space: pre-line"
+          >
+            {{
+              !entry.title || !entry.description
+                ? 'Please make sure you have a title and description'
+                : !entry.prompt
+                  ? 'Please select a prompt'
+                  : !entry.image
+                    ? 'Please select an image'
+                    : 'Please make sure all fields are filled'
+            }}
+          </q-tooltip>
+        </q-btn>
       </q-form>
     </q-card-section>
   </q-card>


### PR DESCRIPTION
Added additional visible indications for users to know the image is required. Also added additional tooltip messages showing what fields are required depending on what fields are filled. 

<img width="909" alt="Screenshot 2024-08-02 at 16 15 49" src="https://github.com/user-attachments/assets/c7b6fd47-a9c6-44fe-b02e-7b395c732b37">
