### PR TITLE
Fix for not showing available prompt for entries in some cases

### DIFF
--- a/src/components/Posts/TheAnthrogram.vue
+++ b/src/components/Posts/TheAnthrogram.vue
@@ -13,7 +13,7 @@
         <div class="row justify-between" style="justify-content: space-between; gap: 10px">
           <div
             v-if="!!visitorStore?.getVisitors?.length"
-            v-bind:class="!!statStore.getStats?.length ? 'col-md-6' : 'col-md-12'"
+            v-bind:class="statStore.getStats && hasValidStats ? 'col-md-6' : 'col-md-12'"
             class="col-12 anthogram-border"
           >
             <VisitorsBar :data="visitorStore?.getVisitors" :interval="interval" />


### PR DESCRIPTION
In some cases, (after previous fix) for example for writers there are no available prompts showing in the menu when creating an entry. Fixed this by fetching all available prompts if there are none in the store loaded.  