### PR TITLE
fix:#541 Fix image resizing, so tall images are correctly handled

### DIFF
--- a/src/pages/IndexPage.vue
+++ b/src/pages/IndexPage.vue
@@ -6,14 +6,22 @@
       <section class="text-center">
         <h2 class="q-my-md text-h6">Welcome to Celebrity Fanalyzer!</h2>
         <RouterLink to="month">
-          <q-img
-            loading="eager"
-            fetchpriority="high"
-            :src="monthPrompt?.image"
-            style="border: 3px solid #e54757; border-radius: 12px"
-            data-test="month-link"
-            no-spinner
-          />
+          <q-responsive :ratio="1" :style="{ backgroundImage: `url(${monthPrompt?.image})`, borderRadius: '300px' }">
+            <div class="bg-blur flex">
+              <q-img
+                fit="contain"
+                ratio="1"
+                spinner-color="primary"
+                :src="monthPrompt?.image"
+                :srcset="`${monthPrompt?.image} 2x`"
+                sizes="(max-width: 560) 50vw, 100vw"
+                data-test="month-link"
+                style="border: 3px solid #e54757; border-radius: 12px"
+                loading="eager"
+                fetchpriority="high"
+              />
+            </div>
+          </q-responsive>
         </RouterLink>
         <p class="q-my-md text-body1">
           This Month's Prompt:
@@ -219,7 +227,7 @@ a {
   }
 }
 
-.prompt-img {
-  background-color: #e54757;
+.bg-blur {
+  backdrop-filter: blur(60px);
 }
 </style>

--- a/src/utils/imageConvertor.js
+++ b/src/utils/imageConvertor.js
@@ -12,11 +12,26 @@ export async function uploadAndSetImage(imageFile, filePathAndName) {
       const img = new Image()
 
       img.onload = async () => {
+        const MAX_WIDTH = 2560
+        const MAX_HEIGHT = 1440
+        let width = img.width
+        let height = img.height
+
+        if (width > MAX_WIDTH || height > MAX_HEIGHT) {
+          const widthRatio = MAX_WIDTH / width
+          const heightRatio = MAX_HEIGHT / height
+          const ratio = Math.min(widthRatio, heightRatio)
+
+          width = width * ratio
+          height = height * ratio
+        }
+
         const canvas = document.createElement('canvas')
         const ctx = canvas.getContext('2d')
-        canvas.width = img.width > 2560 ? img.width / 2 : img.width
-        canvas.height = img.height > 1440 ? img.height / 2 : img.height
-        ctx.drawImage(img, 0, 0, img.width > 2560 ? img.width / 2 : img.width, img.height > 1440 ? img.height / 2 : img.height)
+        canvas.width = width
+        canvas.height = height
+
+        ctx.drawImage(img, 0, 0, width, height)
 
         canvas.toBlob(async (blob) => {
           try {


### PR DESCRIPTION
The new width and height are calculated based on the aspect ratio, using the smaller of the width and height ratios if the image exceeds the maximum allowed dimensions.

This ensures that the aspect ratio is preserved, so no distortion occurs during resizing.