### PR TITLE
feat:#534 implemented loading skeleton cards to be a specific number and responsie to UI

### DIFF
--- a/src/components/shared/ArticleSkeleton.vue
+++ b/src/components/shared/ArticleSkeleton.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="q-pt-md q-px-md relative-position row">
+  <article class="q-pa-md relative-position row skeleton-card">
     <div class="col-8">
       <div class="flex items-center q-mb-sm">
         <q-skeleton type="QAvatar" size="2rem" />
@@ -12,6 +12,30 @@
       </div>
     </div>
     <q-skeleton class="col-4" square style="aspect-ratio: 1; border-radius: 24px" />
-    <q-separator class="full-width q-mt-md" />
   </article>
 </template>
+
+<style scoped lang="scss">
+.skeleton-card {
+  min-width: 619px;
+  width: 100%;
+  border-radius: 24px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+
+  @media (max-width: 1440px) {
+    min-width: 590px;
+  }
+
+  @media (min-width: 1024px) {
+    min-width: 470px;
+  }
+
+  @media (max-width: 768px) {
+    min-width: 361px;
+  }
+
+  @media (max-width: 425px) {
+    min-width: 280px;
+  }
+}
+</style>

--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -21,15 +21,12 @@
           unelevated
         />
       </q-scroll-area>
-      <section v-if="!promptStore.getPrompts && promptStore.isLoading">
-        <ArticleSkeleton />
-        <ArticleSkeleton />
-        <ArticleSkeleton />
-        <ArticleSkeleton />
-      </section>
       <q-tab-panels animated swipeable v-model="category">
         <q-tab-panel v-for="(categ, i) in computedCategories" class="panel" :key="i" :name="categ.value">
-          <TransitionGroup name="prompt" tag="div" class="card-items-wrapper">
+          <section class="card-items-wrapper" v-if="!promptStore.getPrompts && promptStore.isLoading">
+            <ArticleSkeleton v-for="n in skeletons" :key="n" />
+          </section>
+          <TransitionGroup name="prompt" tag="div" class="card-items-wrapper" v-else>
             <ItemCard
               v-for="prompt in computedPromptsAndAdvertises"
               :key="prompt?.id"
@@ -53,7 +50,7 @@ import ItemCard from 'src/components/shared/ItemCard.vue'
 import TheEntries from 'src/components/shared/TheEntries.vue'
 import TheHeader from 'src/components/shared/TheHeader.vue'
 import { useAdvertiseStore, useEntryStore, useErrorStore, usePromptStore } from 'src/stores'
-import { computed, ref ,onUnmounted} from 'vue'
+import { computed, ref, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 
 const entryStore = useEntryStore()
@@ -64,11 +61,12 @@ const advertiseStore = useAdvertiseStore()
 const category = ref('All')
 const router = useRouter()
 const search = ref('')
+const skeletons = 10
 
 advertiseStore.getActiveAdvertise().catch((error) => errorStore.throwError(error))
 promptStore.fetchPrompts().catch((error) => errorStore.throwError(error))
 
-onUnmounted(()=>{
+onUnmounted(() => {
   advertiseStore.reset()
 })
 


### PR DESCRIPTION
The amount of skeletons currently is set to 10 but could be set in the future based on the amount of the lazy loaded prompts that will be fetched.

<img width="1727" alt="Screenshot 2024-09-11 at 18 09 41" src="https://github.com/user-attachments/assets/c8d54a19-e231-463a-8e40-ceed41f6f65d">
<img width="520" alt="Screenshot 2024-09-11 at 18 10 06" src="https://github.com/user-attachments/assets/7329516e-b3fb-4f83-9fcd-31e57b3de3e8">
<img width="949" alt="Screenshot 2024-09-11 at 18 10 00" src="https://github.com/user-attachments/assets/a1a9b48b-9db4-4dc6-af85-9c551589fa58">
<img width="1410" alt="Screenshot 2024-09-11 at 18 09 46" src="https://github.com/user-attachments/assets/2781736e-a4e0-4a09-bef3-67aa72ae50ef">
