### PR TITLE
feat:#548 added escrow id for entries on writers admin panel

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -27,20 +27,20 @@
           </template>
         </q-select>
         <q-input
-        counter
-        data-test="input-title"
-        label="Title"
-        maxlength="80"
-        required
-        v-model="entry.title"
-        :hint="!entry.title ? '*Title is required':''"
-         />
+          counter
+          data-test="input-title"
+          label="Title"
+          maxlength="80"
+          required
+          v-model="entry.title"
+          :hint="!entry.title ? '*Title is required' : ''"
+        />
         <q-field
-        counter
-        label="Description"
-        maxlength="400"
-        v-model="entry.description"
-        :hint="!entry.description ? '*Description is required':''"
+          counter
+          label="Description"
+          maxlength="400"
+          v-model="entry.description"
+          :hint="!entry.description ? '*Description is required' : ''"
         >
           <template v-slot:control>
             <q-editor
@@ -79,7 +79,7 @@
           counter
           data-test="file-image"
           :disable="!entry.prompt"
-          :hint="!entry.prompt ? 'Select prompt first' :!entry.image ? '*Image is required. Max size is 2MB.':''"
+          :hint="!entry.prompt ? 'Select prompt first' : !entry.image ? '*Image is required. Max size is 2MB.' : ''"
           label="Image"
           :max-total-size="2097152"
           :required="!id"
@@ -158,7 +158,7 @@ const promptOptions = computed(
   () =>
     promptStore.getPrompts
       ?.filter((prompt) => !prompt.hasWinner)
-      .map((prompt) => ({ label: `${prompt.date} – ${prompt.title}`, value: prompt.date }))
+      .map((prompt) => ({ label: `${prompt.date} – ${prompt.title}`, value: prompt.date, escrowId: prompt.escrowId }))
       .reverse() || []
 )
 

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -113,10 +113,10 @@ export const useEntryStore = defineStore('entries', {
             entry.author = userStore.getUserById(entry.author.id) || (await userStore.fetchUser(entry.author.id))
           }
 
-          if (promptId && !entry.escrowId) {
+          if (!entry.escrowId) {
             const promptSnapshot = await getDocs(query(collection(db, 'prompts'), where('id', '==', promptId)))
-            const snap = promptSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))[0]
-            entry.escrowId = snap.escrowId
+            const prompt = promptSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))[0]
+            entry.escrowId = prompt.escrowId
           }
         }
         this._userRelatedEntries = entries
@@ -199,11 +199,13 @@ export const useEntryStore = defineStore('entries', {
       const entry = { ...payload }
 
       const promptId = entry.prompt.value
+      const escrowId = entry.prompt.escrowId
       const entryRef = doc(db, 'entries', entry.id)
 
       entry.author = doc(db, 'users', entry.author.value)
       entry.created = Timestamp.fromDate(new Date())
       entry.prompt = promptStore.getPromptRef(entry.prompt.value)
+      entry.escrowId = escrowId || null
 
       this._isLoading = true
       await setDoc(entryRef, entry).finally(() => (this._isLoading = false))

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -108,8 +108,15 @@ export const useEntryStore = defineStore('entries', {
         const entries = snapshotDocs(querySnapshot.docs)
 
         for (const entry of entries) {
+          const promptId = entry.prompt.id
           if (entry.author.id) {
             entry.author = userStore.getUserById(entry.author.id) || (await userStore.fetchUser(entry.author.id))
+          }
+
+          if (promptId && !entry.escrowId) {
+            const promptSnapshot = await getDocs(query(collection(db, 'prompts'), where('id', '==', promptId)))
+            const snap = promptSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))[0]
+            entry.escrowId = snap.escrowId
           }
         }
         this._userRelatedEntries = entries

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -116,7 +116,7 @@ export const useEntryStore = defineStore('entries', {
           if (!entry.escrowId) {
             const promptSnapshot = await getDocs(query(collection(db, 'prompts'), where('id', '==', promptId)))
             const prompt = promptSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }))[0]
-            entry.escrowId = prompt.escrowId
+            entry.escrowId = prompt?.escrowId
           }
         }
         this._userRelatedEntries = entries


### PR DESCRIPTION
In order for writers to be able to withdraw money in case they are winners, there should be an escrowId for each entry. 
This fix will fetch from prompts, escrow id for each entry that doesn't have an escrowId. 

On creation phase of entry, escrowId will be populated with correct id. 

<img width="1723" alt="Screenshot 2024-09-12 at 14 44 23" src="https://github.com/user-attachments/assets/ea3bccd4-b861-45f1-ad8c-55cc126219e8">
