### PR TITLE
565 add clickable links for entry title and author name

### DIFF
--- a/src/components/Admin/ManagePromptsEntries.vue
+++ b/src/components/Admin/ManagePromptsEntries.vue
@@ -38,7 +38,21 @@
             </q-tooltip>
           </q-btn>
         </q-td>
-        <q-td v-for="col in props.cols" :key="col.name" :props="props">{{ col.value }}</q-td>
+        <q-td>
+          <span>
+            {{ props.row.date }}
+          </span>
+        </q-td>
+        <q-td>
+          <a :href="getAuthorLink(props.row?.author?.uid)" class="q-mr-sm" @click.prevent="navigateToAuthor(props.row?.author?.uid)">
+            {{ props.row.author?.displayName }}
+          </a>
+        </q-td>
+        <q-td>
+          <a :href="getTitleLink(props.row?.slug)" class="q-mr-sm" @click.prevent="navigateToTitle(props.row?.slug)">
+            {{ props.row.title }}
+          </a>
+        </q-td>
         <q-td class="text-right">
           <q-btn
             v-if="userStore.isEditorOrAbove"
@@ -113,15 +127,15 @@
 import { useQuasar } from 'quasar'
 import TableEntry from 'src/components/Admin/TableEntry.vue'
 import { useEntryStore, useErrorStore, usePromptStore, useUserStore } from 'src/stores'
-import { computed, onMounted, watchEffect, ref } from 'vue'
-
-defineEmits(['openPromptDialog', 'openAdvertiseDialog'])
+import { computed, onMounted, ref, watchEffect } from 'vue'
+import { useRouter } from 'vue-router'
 
 const $q = useQuasar()
 const entryStore = useEntryStore()
 const errorStore = useErrorStore()
 const promptStore = usePromptStore()
 const userStore = useUserStore()
+const router = useRouter()
 
 const columns = [
   {},
@@ -147,6 +161,22 @@ onMounted(async () => {
 
 const isLoaded = computed(() => promptStore.getPrompts)
 const isLoading = computed(() => promptStore.isLoading || (entryStore.isLoading && !isLoaded.value))
+
+function getAuthorLink(author) {
+  return `/fan/${author}`
+}
+
+function getTitleLink(prompt) {
+  return `${prompt}`
+}
+
+function navigateToAuthor(author) {
+  router.push(getAuthorLink(author))
+}
+
+function navigateToTitle(prompt) {
+  router.push(getTitleLink(prompt))
+}
 
 watchEffect(async () => {
   prompts.value = promptStore.getPrompts

--- a/src/components/Admin/TableEntry.vue
+++ b/src/components/Admin/TableEntry.vue
@@ -2,9 +2,8 @@
   <q-table
     flat
     :hide-bottom="!!rows.length"
-    :class="{ 'entries-table': !userStore.isEditorOrAbove }"
+    :class="{ 'entries-table ': !userStore.isEditorOrAbove }"
     :columns="!!rows.length ? columns : []"
-    :dense="userStore.isEditorOrAbove"
     :filter="filter"
     :bordered="!userStore.isEditorOrAbove"
     :hide-header="userStore.isEditorOrAbove"
@@ -14,97 +13,111 @@
     no-data-label="No entries found."
     :loading="entryStore.isLoading"
   >
-    <template #body-cell-created="props">
-      <td class="text-center relative-position">
-        <img v-if="props.row.isWinner" src="/favicon-16x16.png" style="position: absolute; left: 3%" />
-        {{ dayMonthYear(props.row.created) }}
-      </td>
-    </template>
-    <template v-slot:body-cell-actions="props">
-      <td class="text-right">
-        <q-btn
-          v-if="
-            userStore.isEditorOrAbove &&
-            props.row.isWinner !== true &&
-            _currentPrompt?.isTreated !== true &&
-            _currentPrompt?.hasWinner !== true
-          "
-          color="black"
-          :disable="userStore.getUser.role !== 'Admin'"
-          flat
-          size="sm"
-          icon="toggle_off"
-          @click="onSelectWinnerDialog(props.row)"
-        >
-          <q-tooltip class="positive" :offset="[10, 10]">select winner!</q-tooltip>
-        </q-btn>
-        <q-btn
-          v-if="props.row.isWinner === true && _currentPrompt?.isTreated !== true"
-          color="dark"
-          :disable="userStore.getUser.role !== 'Admin'"
-          flat
-          icon="payment"
-          size="sm"
-          label=""
-          @click="onProceedPaymentDialog(props.row)"
-        >
-          <q-tooltip class="positive" :offset="[10, 10]">proceed payment!</q-tooltip>
-        </q-btn>
-        <q-btn
-          v-if="props.row.isWinner === true && _currentPrompt?.isTreated === true"
-          color="dark"
-          :disable="userStore.getUser.role !== 'Admin'"
-          flat
-          icon="payment"
-          size="sm"
-          label=""
-          @click="onProceedPaymentDialog(props.row)"
-        >
-          <q-tooltip class="positive" :offset="[10, 10]">view transaction detail!</q-tooltip>
-        </q-btn>
-        <q-btn
-          v-if="props.row.isWinner === true && _currentPrompt?.isTreated !== true"
-          color="positive"
-          flat
-          icon="toggle_on"
-          size="sm"
-          label=""
-          :disable="userStore.getUser.role !== 'Admin'"
-          @click="onSelectWinnerDialog(props.row)"
-        >
-          <q-tooltip class="negative" :offset="[10, 10]">unselect winner!</q-tooltip>
-        </q-btn>
+    <template v-slot:body="props">
+      <q-tr class="new" :data-test="props.key" :props="props">
+        <q-td>
+          <span style="display: flex; width: 34px; place-content: center">
+            <img alt="winner-logo" v-if="props.row.isWinner" src="/favicon-16x16.png" />
+          </span>
+        </q-td>
+        <q-td class="q-table--col-auto-width">
+          <span>{{ dayMonthYear(props.row.created) }}</span>
+        </q-td>
+        <q-td>
+          <a :href="getAuthorLink(props.row?.author?.uid)" @click.prevent="navigateToAuthor(props.row?.author?.uid)">
+            {{ props.row.author?.displayName }}
+          </a>
+        </q-td>
+        <q-td>
+          <a :href="getTitleLink(props.row?.slug)" @click.prevent="navigateToTitle(props.row?.slug)">
+            {{ props.row.title }}
+          </a>
+        </q-td>
+        <q-td class="text-right">
+          <q-btn
+            v-if="
+              userStore.isEditorOrAbove &&
+              props.row.isWinner !== true &&
+              _currentPrompt?.isTreated !== true &&
+              _currentPrompt?.hasWinner !== true
+            "
+            color="black"
+            :disable="userStore.getUser.role !== 'Admin'"
+            flat
+            size="sm"
+            icon="toggle_off"
+            @click="onSelectWinnerDialog(props.row)"
+          >
+            <q-tooltip class="positive" :offset="[10, 10]">select winner!</q-tooltip>
+          </q-btn>
+          <q-btn
+            v-if="props.row.isWinner === true && _currentPrompt?.isTreated !== true"
+            color="dark"
+            :disable="userStore.getUser.role !== 'Admin'"
+            flat
+            icon="payment"
+            size="sm"
+            label=""
+            @click="onProceedPaymentDialog(props.row)"
+          >
+            <q-tooltip class="positive" :offset="[10, 10]">proceed payment!</q-tooltip>
+          </q-btn>
+          <q-btn
+            v-if="props.row.isWinner === true && _currentPrompt?.isTreated === true"
+            color="dark"
+            :disable="userStore.getUser.role !== 'Admin'"
+            flat
+            icon="payment"
+            size="sm"
+            label=""
+            @click="onProceedPaymentDialog(props.row)"
+          >
+            <q-tooltip class="positive" :offset="[10, 10]">view transaction detail!</q-tooltip>
+          </q-btn>
+          <q-btn
+            v-if="props.row.isWinner === true && _currentPrompt?.isTreated !== true"
+            color="positive"
+            flat
+            icon="toggle_on"
+            size="sm"
+            label=""
+            :disable="userStore.getUser.role !== 'Admin'"
+            @click="onSelectWinnerDialog(props.row)"
+          >
+            <q-tooltip class="negative" :offset="[10, 10]">unselect winner!</q-tooltip>
+          </q-btn>
 
-        <span v-if="_currentPrompt?.hasWinner !== true">
-          <span v-if="props.row.isWinner !== true">
-            <q-btn
-              v-if="userStore.isEditorOrAbove || userStore.getUser.uid === props.row.author.uid"
-              color="warning"
-              flat
-              icon="edit"
-              round
-              size="sm"
-              @click="onEditDialog(props.row)"
-            >
-              <q-tooltip>Edit</q-tooltip>
-            </q-btn>
+          <span v-if="_currentPrompt?.hasWinner !== true">
+            <span v-if="props.row.isWinner !== true">
+              <q-btn
+                v-if="userStore.isEditorOrAbove || userStore.getUser.uid === props.row.author.uid"
+                color="warning"
+                flat
+                icon="edit"
+                round
+                size="sm"
+                @click="onEditDialog(props.row)"
+              >
+                <q-tooltip>Edit</q-tooltip>
+              </q-btn>
+            </span>
+            <span v-if="props.row.isWinner !== true">
+              <q-btn
+                v-if="userStore.isEditorOrAbove || userStore.getUser.uid === props.row.author.uid"
+                color="negative"
+                data-test="button-delete-entry"
+                flat
+                icon="delete"
+                round
+                size="sm"
+                @click="onDeleteDialog(props.row)"
+              >
+                <q-tooltip>Delete</q-tooltip>
+              </q-btn>
+            </span>
           </span>
-          <span v-if="props.row.isWinner !== true">
-            <q-btn
-              v-if="userStore.isEditorOrAbove || userStore.getUser.uid === props.row.author.uid"
-              color="negative"
-              data-test="button-delete-entry"
-              flat
-              icon="delete"
-              round
-              size="sm"
-              @click="onDeleteDialog(props.row)"
-            >
-              <q-tooltip>Delete</q-tooltip>
-            </q-btn>
-          </span>
-        </span>
-      </td>
+        </q-td>
+      </q-tr>
     </template>
   </q-table>
 
@@ -186,6 +199,7 @@ import EntryCard from './EntryCard.vue'
 import WalletPaymentCard from './WalletPaymentCard.vue'
 import CryptoTransactionDetailCard from './CryptoTransactionDetailCard.vue'
 import { useCryptoTransactionStore } from 'app/src/stores/crypto-transactions'
+import { useRouter } from 'vue-router'
 
 const props = defineProps({
   filter: { type: String, required: false, default: '' },
@@ -208,13 +222,31 @@ const errorStore = useErrorStore()
 const promptStore = usePromptStore()
 const userStore = useUserStore()
 const cryptoTransactions = useCryptoTransactionStore()
+const router = useRouter()
 
 const columns = [
-  { name: 'created', align: 'center', label: 'Created', field: (row) => shortMonthDayTime(row.created), sortable: true },
-  { name: 'author', align: 'center', label: 'Author', field: (row) => row.author?.displayName },
+  {},
+  { name: 'created', align: 'left', label: 'Created', field: (row) => shortMonthDayTime(row.created), sortable: true },
+  { name: 'author', align: 'left', label: 'Author', field: (row) => row.author?.displayName },
   { name: 'title', align: 'left', label: 'Title', field: 'title', sortable: true },
-  { name: 'actions', field: 'actions' }
+  {}
 ]
+
+function getAuthorLink(author) {
+  return `/fan/${author}`
+}
+
+function getTitleLink(slug) {
+  return `${slug}`
+}
+
+function navigateToAuthor(author) {
+  router.push(getAuthorLink(author))
+}
+
+function navigateToTitle(slug) {
+  router.push(getTitleLink(slug))
+}
 
 const deleteDialog = ref({})
 const entry = ref({})
@@ -325,5 +357,9 @@ function onSelectWinner(entry) {
 <style scoped>
 .entries-table {
   margin: 1rem 1rem 0 1rem;
+}
+
+td {
+  font-size: 12px !important;
 }
 </style>

--- a/src/components/Admin/TableEntry.vue
+++ b/src/components/Admin/TableEntry.vue
@@ -15,26 +15,27 @@
   >
     <template v-slot:body="props">
       <q-tr class="new" :data-test="props.key" :props="props">
-        <q-td>
+        <q-td style="width: 34px">
           <span style="display: flex; width: 34px; place-content: center">
             <img alt="winner-logo" v-if="props.row.isWinner" src="/favicon-16x16.png" />
           </span>
         </q-td>
-        <q-td class="q-table--col-auto-width">
-          <span>{{ dayMonthYear(props.row.created) }}</span>
+        <q-td auto-width style="width: 101px">
+          <div>{{ dayMonthYear(props.row.created) }}</div>
         </q-td>
-        <q-td>
-          <a :href="getAuthorLink(props.row?.author?.uid)" @click.prevent="navigateToAuthor(props.row?.author?.uid)">
+        <q-td :style="widthStyle" style="text-align: center">
+          <a :href="`/fan/${props.row?.author?.uid}`" @click.prevent="router.push(`/fan/${props.row?.author?.uid}`)">
             {{ props.row.author?.displayName }}
           </a>
         </q-td>
         <q-td>
-          <a :href="getTitleLink(props.row?.slug)" @click.prevent="navigateToTitle(props.row?.slug)">
+          <a :href="props.row?.slug" @click.prevent="router.push(props.row?.slug)">
             {{ props.row.title }}
           </a>
         </q-td>
         <q-td class="text-right">
           <q-btn
+            class="payment-buttons"
             v-if="
               userStore.isEditorOrAbove &&
               props.row.isWinner !== true &&
@@ -51,6 +52,7 @@
             <q-tooltip class="positive" :offset="[10, 10]">select winner!</q-tooltip>
           </q-btn>
           <q-btn
+            class="payment-buttons"
             v-if="props.row.isWinner === true && _currentPrompt?.isTreated !== true"
             color="dark"
             :disable="userStore.getUser.role !== 'Admin'"
@@ -63,6 +65,7 @@
             <q-tooltip class="positive" :offset="[10, 10]">proceed payment!</q-tooltip>
           </q-btn>
           <q-btn
+            class="payment-buttons"
             v-if="props.row.isWinner === true && _currentPrompt?.isTreated === true"
             color="dark"
             :disable="userStore.getUser.role !== 'Admin'"
@@ -75,6 +78,7 @@
             <q-tooltip class="positive" :offset="[10, 10]">view transaction detail!</q-tooltip>
           </q-btn>
           <q-btn
+            class="payment-buttons"
             v-if="props.row.isWinner === true && _currentPrompt?.isTreated !== true"
             color="positive"
             flat
@@ -194,7 +198,7 @@
 import { useQuasar } from 'quasar'
 import { useEntryStore, useErrorStore, usePromptStore, useUserStore } from 'src/stores'
 import { dayMonthYear, shortMonthDayTime } from 'src/utils/date'
-import { ref, watchEffect } from 'vue'
+import { nextTick, onMounted, ref, watch } from 'vue'
 import EntryCard from './EntryCard.vue'
 import WalletPaymentCard from './WalletPaymentCard.vue'
 import CryptoTransactionDetailCard from './CryptoTransactionDetailCard.vue'
@@ -205,14 +209,26 @@ const props = defineProps({
   filter: { type: String, required: false, default: '' },
   rows: { type: Array, required: true, default: () => [] },
   currentPrompt: { type: Object },
-  loadedEntries: { type: Array, default: () => [] }
+  loadedEntries: { type: Array, default: () => [] },
+  maxWidth: { type: Number, required: false }
+})
+
+const widthStyle = ref({ width: `${props.maxWidth}px` })
+
+watch(
+  () => props.maxWidth,
+  (newWidth) => {
+    widthStyle.value = { width: `${newWidth}px` }
+  }
+)
+
+onMounted(() => {
+  nextTick(() => {
+    widthStyle.value = { width: `${props.maxWidth}px` }
+  })
 })
 
 const _currentPrompt = ref({})
-
-watchEffect(() => {
-  _currentPrompt.value = props.currentPrompt
-})
 
 // Emit event to parent
 const emit = defineEmits(['update-entry', 'delete-entry'])
@@ -227,26 +243,10 @@ const router = useRouter()
 const columns = [
   {},
   { name: 'created', align: 'left', label: 'Created', field: (row) => shortMonthDayTime(row.created), sortable: true },
-  { name: 'author', align: 'left', label: 'Author', field: (row) => row.author?.displayName },
+  { name: 'author', align: 'center', label: 'Author', field: (row) => row.author?.displayName },
   { name: 'title', align: 'left', label: 'Title', field: 'title', sortable: true },
   {}
 ]
-
-function getAuthorLink(author) {
-  return `/fan/${author}`
-}
-
-function getTitleLink(slug) {
-  return `${slug}`
-}
-
-function navigateToAuthor(author) {
-  router.push(getAuthorLink(author))
-}
-
-function navigateToTitle(slug) {
-  router.push(getTitleLink(slug))
-}
 
 const deleteDialog = ref({})
 const entry = ref({})
@@ -361,5 +361,11 @@ function onSelectWinner(entry) {
 
 td {
   font-size: 12px !important;
+  background-color: rgba(229, 71, 87, 0.12);
+}
+
+.payment-buttons {
+  width: 30px !important;
+  height: 30px !important;
 }
 </style>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -44,3 +44,8 @@ html {
   top: 0;
   z-index: 1 !important;
 }
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}


### PR DESCRIPTION
Implemented clickable table columns each to corresponding endpoint. Clicking on author name should redirect to author profile page. Clicking on prompt or entry title should take you to that specific entry. 

Also I adjusted table UI so when expanding the prompt, entries columns would have the same width and match parent table.
Adjusted entries row color to easily see the differences between prompts and entries. 

<img width="1330" alt="Screenshot 2024-09-14 at 18 15 20" src="https://github.com/user-attachments/assets/ef22256d-bda1-4753-bdec-4cbb6745f423">
<img width="1331" alt="Screenshot 2024-09-14 at 18 15 26" src="https://github.com/user-attachments/assets/ee36931d-280d-4925-aa81-49bd02de9678">
