### PR TITLE
Bugfix/restrict entry name same prompt 573

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -217,13 +217,21 @@ function onPaste(evt) {
 
 async function onSubmit() {
   entry.title = entry.title.trim()
-  const hasEntry = await entryStore.hasEntry(entry.prompt?.value)
+  const hasLoadedEntry = entryStore.checkPromptRelatedEntry(entry.prompt?.value)
+
+  if (!hasLoadedEntry) {
+    await entryStore.fetchEntryByPrompts(entry.prompt?.value)
+  }
+
+  const hasEntry = entryStore.hasEntry(entry.prompt?.value)
+
   if (!props.id && hasEntry) {
     $q.notify({ type: 'info', message: 'You have already submitted an entry for this prompt. Please select another prompt' })
     return
   }
 
-  const entryNameValidator = await entryStore.entryNameValidator(props.id, entry.prompt?.value, entry.title, !!props.id)
+  const entryNameValidator = entryStore.entryNameValidator(props.id, entry.prompt?.value, entry.title, !!props.id)
+
   if (entryNameValidator) {
     $q.notify({ message: 'Entry with this title already exists. Please choose another title.', type: 'negative' })
     return

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -216,6 +216,7 @@ function onPaste(evt) {
 }
 
 async function onSubmit() {
+  entry.title = entry.title.trim()
   const hasEntry = await entryStore.hasEntry(entry.prompt?.value)
   if (!props.id && hasEntry) {
     $q.notify({ type: 'info', message: 'You have already submitted an entry for this prompt. Please select another prompt' })

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -33,7 +33,8 @@
           maxlength="80"
           required
           v-model="entry.title"
-          :hint="!entry.title ? '*Title is required' : ''"
+          :disable="!entry.prompt"
+          :hint="!entry.prompt ? 'Select prompt first' : !entry.title ? '*Title is required' : ''"
         />
         <q-field
           counter
@@ -218,6 +219,12 @@ async function onSubmit() {
   const hasEntry = await entryStore.hasEntry(entry.prompt?.value)
   if (!props.id && hasEntry) {
     $q.notify({ type: 'info', message: 'You have already submitted an entry for this prompt. Please select another prompt' })
+    return
+  }
+
+  const entryNameValidator = await entryStore.entryNameValidator(props.id, entry.prompt?.value, entry.title, !!props.id)
+  if (entryNameValidator) {
+    $q.notify({ message: 'Entry with this title already exists. Please choose another title.', type: 'negative' })
     return
   }
   entry.slug = `/${entry.prompt.value.replace(/\-/g, '/')}/${entry.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')}`

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -295,6 +295,23 @@ export const useEntryStore = defineStore('entries', {
 
     setTab(tab) {
       this.$patch({ _tab: tab })
+    },
+
+    async entryNameValidator(entryId, promptId, title, isEdit = false) {
+      try {
+        const promptDocRef = doc(db, 'prompts', promptId)
+        const conditions = [where('prompt', '==', promptDocRef), where('title', '==', title.trim())]
+
+        if (isEdit) {
+          conditions.push(where('id', '!=', entryId))
+        }
+
+        const entrySnapshot = await getDocs(query(collection(db, 'entries'), and(...conditions)))
+        return !entrySnapshot.empty
+      } catch (error) {
+        console.log('Error occurred while checking', error)
+        return false
+      }
     }
   }
 })

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -300,7 +300,7 @@ export const useEntryStore = defineStore('entries', {
     async entryNameValidator(entryId, promptId, title, isEdit = false) {
       try {
         const promptDocRef = doc(db, 'prompts', promptId)
-        const conditions = [where('prompt', '==', promptDocRef), where('title', '==', title.trim())]
+        const conditions = [where('prompt', '==', promptDocRef), where('title', '==', title)]
 
         if (isEdit) {
           conditions.push(where('id', '!=', entryId))

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -170,19 +170,48 @@ export const useEntryStore = defineStore('entries', {
         console.error('Unable to fetch entry', e)
       }
     },
-    async hasEntry(promptId) {
+    async fetchEntryByPrompts(promptId) {
       const userStore = useUserStore()
+      const promptDocRef = doc(db, 'prompts', promptId)
+
       try {
-        const userDocRef = doc(db, 'users', userStore.getUserId)
-        const promptDocRef = doc(db, 'prompts', promptId)
-        const querySnapshot = await getDocs(
-          query(collection(db, 'entries'), and(where('author', '==', userDocRef), where('prompt', '==', promptDocRef)))
-        )
-        return !querySnapshot.empty
-      } catch (error) {
-        console.log('Unable to check has entry', error)
+        const querySnapshot = await getDocs(query(collection(db, 'entries'), where('prompt', '==', promptDocRef)))
+        const entries = snapshotDocs(querySnapshot.docs)
+
+        const userPromises = entries.map(async (entry) => {
+          if (entry.author.id) {
+            entry.author = userStore.getUserById(entry.author.id) || (await userStore.fetchUser(entry.author.id))
+          }
+          return entry
+        })
+
+        this._entries = await Promise.all(userPromises)
+      } catch (e) {
+        console.error('Unable to fetch entries', e)
+      }
+    },
+
+    hasEntry(promptId) {
+      const userStore = useUserStore()
+
+      const filteredEntry = this.getEntries?.filter((entry) => entry.author.uid === userStore.getUserId && entry.prompt.id === promptId)
+      return !!filteredEntry.length
+    },
+
+    entryNameValidator(entryId, promptId, title, isEdit = false) {
+      const filteredEntry = this.getEntries?.filter((entry) =>
+        isEdit
+          ? entryId !== entry?.id && entry.title === title && promptId === entry.prompt.id
+          : entry.title === title && promptId === entry.prompt.id
+      )
+      return !!filteredEntry.length
+    },
+
+    checkPromptRelatedEntry(promptId) {
+      if (!this.getEntries) {
         return false
       }
+      return !!this.getEntries?.find((entry) => entry.prompt.id === promptId)
     },
 
     async addEntry(payload) {
@@ -295,23 +324,6 @@ export const useEntryStore = defineStore('entries', {
 
     setTab(tab) {
       this.$patch({ _tab: tab })
-    },
-
-    async entryNameValidator(entryId, promptId, title, isEdit = false) {
-      try {
-        const promptDocRef = doc(db, 'prompts', promptId)
-        const conditions = [where('prompt', '==', promptDocRef), where('title', '==', title)]
-
-        if (isEdit) {
-          conditions.push(where('id', '!=', entryId))
-        }
-
-        const entrySnapshot = await getDocs(query(collection(db, 'entries'), and(...conditions)))
-        return !entrySnapshot.empty
-      } catch (error) {
-        console.log('Error occurred while checking', error)
-        return false
-      }
     }
   }
 })


### PR DESCRIPTION
<!--
Please, include:
- A description of the changes proposed in the pull request.
- A reference to a related issue in your repository:
  - Add keyword "close", "fix" or "resolve" to inform the issue related.
    Example: Resolve #123
-->
## Issue: #573 
Users were able to create multiple entries within the same prompt with identical names, leading to potential confusion add data inconsistencies 

## Description
This fix ensures data integrity and eliminates confusion caused by duplicate entries in the same prompt.

Solution:

- Implemented a validation check to restrict the creation of entries with duplicate names within the same prompt.
- Added an error message that is triggered when a user attempts to create an entry with an existing name in the same prompt.
- Refined the logic to enhance the user experience by preventing duplicate entries during form submission.