### PR TITLE
FEAT/#570 Sharing the Entry or Prompt You Just Created

### DIFF
--- a/src/components/Admin/ManagePromptsEntries.vue
+++ b/src/components/Admin/ManagePromptsEntries.vue
@@ -80,6 +80,7 @@
           >
             <q-tooltip>Delete</q-tooltip>
           </q-btn>
+          <ShareComponent dense :label="''" :link="getOrigin(props.row.slug)" @share="share($event, 'prompts', props.row.id)" />
         </q-td>
       </q-tr>
       <q-tr v-show="props.expand" :props="props">
@@ -127,9 +128,10 @@
 <script setup>
 import { useQuasar } from 'quasar'
 import TableEntry from 'src/components/Admin/TableEntry.vue'
-import { useEntryStore, useErrorStore, usePromptStore, useUserStore } from 'src/stores'
+import { useEntryStore, useErrorStore, usePromptStore, useUserStore, useShareStore } from 'src/stores'
 import { computed, onBeforeUnmount, onMounted, ref, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
+import ShareComponent from 'src/components/Posts/ShareComponent.vue'
 
 const $q = useQuasar()
 const entryStore = useEntryStore()
@@ -137,6 +139,8 @@ const errorStore = useErrorStore()
 const promptStore = usePromptStore()
 const userStore = useUserStore()
 const router = useRouter()
+const shareStore = useShareStore()
+
 const columns = [
   {},
   { name: 'date', align: 'center', label: 'Date', field: (row) => row.date, sortable: true },
@@ -234,6 +238,10 @@ async function handleUpdateEntry({ _entry, _prompt }) {
   await promptStore.fetchPrompts()
 }
 
+async function share(socialNetwork, collectionName, id) {
+  await shareStore.addShare(collectionName, id, socialNetwork).catch((error) => errorStore.throwError(error))
+}
+
 function toggleExpand(props) {
   props.expand = !props?.expand
   if (props.expand && !entryStore._loadedEntries.some((el) => el?.promptId === props?.row?.id)) {
@@ -277,5 +285,9 @@ function handleDeleteEntry(entryId, promptId) {
   })
 
   promptStore.fetchPrompts()
+}
+
+function getOrigin(slug) {
+  return window.origin + slug
 }
 </script>

--- a/src/components/Admin/TableEntry.vue
+++ b/src/components/Admin/TableEntry.vue
@@ -120,6 +120,7 @@
               </q-btn>
             </span>
           </span>
+          <ShareComponent dense :label="''" :link="getOrigin(props.row.slug)" @share="share($event, 'entries', props.row.id)" />
         </q-td>
       </q-tr>
     </template>
@@ -196,7 +197,7 @@
 
 <script setup>
 import { useQuasar } from 'quasar'
-import { useEntryStore, useErrorStore, usePromptStore, useUserStore } from 'src/stores'
+import { useEntryStore, useErrorStore, usePromptStore, useUserStore, useShareStore } from 'src/stores'
 import { dayMonthYear, shortMonthDayTime } from 'src/utils/date'
 import { nextTick, onMounted, ref, watch } from 'vue'
 import EntryCard from './EntryCard.vue'
@@ -204,6 +205,7 @@ import WalletPaymentCard from './WalletPaymentCard.vue'
 import CryptoTransactionDetailCard from './CryptoTransactionDetailCard.vue'
 import { useCryptoTransactionStore } from 'app/src/stores/crypto-transactions'
 import { useRouter } from 'vue-router'
+import ShareComponent from 'src/components/Posts/ShareComponent.vue'
 
 const props = defineProps({
   filter: { type: String, required: false, default: '' },
@@ -239,6 +241,7 @@ const promptStore = usePromptStore()
 const userStore = useUserStore()
 const cryptoTransactions = useCryptoTransactionStore()
 const router = useRouter()
+const shareStore = useShareStore()
 
 const columns = [
   {},
@@ -266,6 +269,10 @@ function onEditDialog(props) {
 function onDeleteDialog(entry) {
   deleteDialog.value.show = true
   deleteDialog.value.entry = entry
+}
+
+async function share(socialNetwork, collectionName, id) {
+  await shareStore.addShare(collectionName, id, socialNetwork).catch((error) => errorStore.throwError(error))
 }
 
 async function onProceedPaymentDialog(props) {
@@ -352,6 +359,10 @@ function onSelectWinner(entry) {
     })
 
   selectWinnerDialog.value.show = false
+}
+
+function getOrigin(slug) {
+  return window.origin + slug
 }
 </script>
 <style scoped>

--- a/src/components/Posts/ShareComponent.vue
+++ b/src/components/Posts/ShareComponent.vue
@@ -6,6 +6,7 @@
     icon="share"
     :label="label"
     rounded
+    :dense="dense"
     size="0.75rem"
     @click="onShare()"
   >
@@ -19,7 +20,7 @@ import { copyToClipboard, useQuasar } from 'quasar'
 const $q = useQuasar()
 
 const emit = defineEmits(['share'])
-defineProps(['label', 'disable'])
+const props = defineProps(['label', 'disable', 'link', 'dense'])
 
 function onShare() {
   $q.bottomSheet({
@@ -44,11 +45,14 @@ function onShare() {
     ]
   }).onOk((action) => {
     if (action.id === 'clipboard') {
-      copyToClipboard(window.location.href)
+      copyToClipboard(props?.link ? props.link : window.location.href)
     } else if (action.id === 'facebook' || action.id === 'linkedin') {
-      window.open(action.link + `${window.location.href}`, '_blank')
+      window.open(action.link + `${props?.link ? props.link : window.location.href}`, '_blank')
     } else {
-      window.open(action.link + `Look what I just found on CelebrityFanalyzer: ${window.location.href}`, '_blank')
+      window.open(
+        action.link + `Look what I just found on CelebrityFanalyzer: ${props?.link ? props.link : window.location.href}`,
+        '_blank'
+      )
     }
 
     emit('share', action.id)


### PR DESCRIPTION
<!--
Please, include:
- A description of the changes proposed in the pull request.
- A reference to a related issue in your repository:
  - Add keyword "close", "fix" or "resolve" to inform the issue related.
    Example: Resolve #123
-->
### Issue #570 

## Description
 - Added the ability to directly share specific prompts and entries from the **Manage Prompts & Entries** table.
 - Integrated the sharing functionality using `ShareComponent.vue`.
 - Users can now easily share specific prompts and entries via the new share option in the table.
