### PR TITLE
fix:#609 - fixing bug and check escrow id for entry

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -158,7 +158,7 @@ const imageModel = ref([])
 const promptOptions = computed(
   () =>
     promptStore.getPrompts
-      ?.filter((prompt) => !prompt.hasWinner)
+      ?.filter((prompt) => !prompt.hasWinner && prompt.escrowId)
       .map((prompt) => ({ label: `${prompt.date} – ${prompt.title}`, value: prompt.date, escrowId: prompt.escrowId }))
       .reverse() || []
 )

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -163,15 +163,9 @@ const promptOptions = computed(
       .reverse() || []
 )
 
-watchEffect(() => {
-  if (!promptStore.getPrompts) {
-    promptStore.fetchPrompts()
-  }
-})
-
 onMounted(() => {
+  promptStore.fetchPrompts()
   userStore.getAdminsAndEditors.forEach((user) => authorOptions.push({ label: user.displayName, value: user.uid }))
-
   if (props.id) {
     entry.author = { label: props.author?.displayName, value: props.author?.uid }
     entry.description = props.description

--- a/src/components/Admin/PromptCard.vue
+++ b/src/components/Admin/PromptCard.vue
@@ -48,20 +48,20 @@
               v-model="prompt.author"
             />
             <q-input
-            counter
-            data-test="input-title"
-            label="Title"
-            maxlength="80"
-            required
-            v-model="prompt.title"
-            :hint="!prompt.title ? '*Title is required':''"
+              counter
+              data-test="input-title"
+              label="Title"
+              maxlength="80"
+              required
+              v-model="prompt.title"
+              :hint="!prompt.title ? '*Title is required' : ''"
             />
             <q-field
-            counter
-            label="Description"
-            maxlength="400"
-            v-model="prompt.description"
-            :hint="!prompt.description ? '*Description is required':''"
+              counter
+              label="Description"
+              maxlength="400"
+              v-model="prompt.description"
+              :hint="!prompt.description ? '*Description is required' : ''"
             >
               <template v-slot:control>
                 <q-editor
@@ -99,7 +99,7 @@
               accept=".jpg, image/*"
               counter
               data-test="file-image"
-              :hint="!prompt.image ? '*Image is required. Max size is 2MB.':''"
+              :hint="!prompt.image ? '*Image is required. Max size is 2MB.' : ''"
               label="Image"
               :max-total-size="2097152"
               :required="!id"
@@ -253,7 +253,7 @@ async function onSubmit() {
     return
   }
   if (!promptStore.getPrompts) {
-    const hasPrompt = await promptStore.hasPrompt(prompt.date, prompt.title, prompt.slug,!!props.id)
+    const hasPrompt = await promptStore.hasPrompt(prompt.date, prompt.title, prompt.slug, !!props.id)
     if (hasPrompt) {
       return
     }
@@ -277,7 +277,7 @@ async function onSubmit() {
   } else {
     await promptStore
       .addPrompt(prompt)
-      .then(() => $q.notify({ type: 'positive', message: 'Prompt successfully submitted' }))
+      .then(() => $q.notify({ type: 'positive', message: 'Prompt successfully submitted. Please make sure to fund it.' }))
       .catch((error) => errorStore.throwError(error, 'Prompt submission failed'))
   }
 


### PR DESCRIPTION
## Description

Restricted entry creation for unfunded prompts (prompts that don't have an escrowId). 
Also fixed the issues with cached prompts in the prompts menu when creating entry (it required clearing cache to be able to see a new prompt, now it will fetch for new prompts each time the dropdown is opened)