### PR TITLE
fix:#616 - Inaccurate Advertise status for published advertise

### DIFF
--- a/src/components/Advertiser/AdvertiserTable.vue
+++ b/src/components/Advertiser/AdvertiserTable.vue
@@ -630,6 +630,8 @@ function showStatus(data) {
     return 'Budget Crossed'
   } else if (ended || data.status === 'Complete') {
     return 'Complete'
+  } else if (data.status === 'Active') {
+    return 'Published'
   } else if (create && !ended && data.status !== 'Budget Crossed') {
     return 'Ready to Publish'
   }


### PR DESCRIPTION
<!--
Please, include:
- A description of the changes proposed in the pull request.
- A reference to a related issue in your repository:
  - Add keyword "close", "fix" or "resolve" to inform the issue related.
    Example: Resolve #123
-->
### Issue: #616 
## Description

- Fixed the inaccurate advertisement status for published ads. Once the advertisement has been published, the status shows as `Published`.

![Screenshot from 2024-10-04 15-21-03](https://github.com/user-attachments/assets/c21cad4d-a68d-4961-b551-648f300f7d4d)
