### PR TITLE
feat:#635 - implemented display no entries message & button

### DIFF
--- a/src/components/shared/TheHeader.vue
+++ b/src/components/shared/TheHeader.vue
@@ -251,6 +251,10 @@ function handleKeyUpDate(event) {
   }
   emit('updateSearchDate', selectedDate.value)
 }
+
+defineExpose({
+  openEntryDialog
+})
 </script>
 <style scoped>
 .filter-card {

--- a/src/pages/PublicProfilePage.vue
+++ b/src/pages/PublicProfilePage.vue
@@ -1,5 +1,5 @@
 <template>
-  <TheHeader v-if="user?.uid" feedbackButton :title="user.role + ' Profile'" />
+  <TheHeader v-if="user?.uid" ref="header" feedbackButton :title="user.role + ' Profile'" />
   <q-page-container>
     <q-page v-if="user?.uid">
       <q-card flat>
@@ -28,7 +28,19 @@
         </q-card-section>
         <q-separator spaced inset />
         <q-card-section class="justify-center row">
+          <div v-if="computedPosts.length === 0 && user?.uid === userStore.getUser?.uid" class="text-center q-mt-md">
+            <p class="text-h6">It looks like you haven't created any entries yet.</p>
+            <p>
+              Start sharing your thoughts and experiences with the
+              <b><i>Celebrity Fanalyzer!</i></b>
+            </p>
+            <q-btn label="Create Your First Entry" @click="header?.openEntryDialog()" color="primary" class="q-mt-md" rounded unelevated />
+          </div>
+          <div v-else-if="computedPosts.length === 0" class="text-center q-mt-md">
+            <p class="text-h6">This user has not created any entries yet.</p>
+          </div>
           <div
+            v-else
             v-for="post in computedPosts"
             class="col-sm-4 col-xs-6"
             :key="post.id"
@@ -74,6 +86,7 @@ const userStore = useUserStore()
 const $q = useQuasar()
 
 const user = ref()
+const header = ref(null)
 
 const socialNetworks = [
   { name: 'facebook', link: 'https://facebook.com/' },


### PR DESCRIPTION
## 🛠 Description
### implemented new users interface in profile view ( when no entries exist on the profile.)
#### when a user views their own profile :
Display a message :
![Screenshot from 2024-10-16 17-11-05](https://github.com/user-attachments/assets/2f01c2eb-5855-4bc4-bfd7-910c18087497)

#### when another user views their different profile :
![Screenshot from 2024-10-16 17-11-58](https://github.com/user-attachments/assets/916ea66f-8880-4d35-b789-c14f171ebe27)

Fixes #635 
I used The `defineExpose` function allows a controlled and clean way to make specific internal methods available to the parent or other components.

### ✨ Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🧪 All Test Suites Passed?

- [x] Manual tested
- [x] Vitest
- [ ] Cypress

### 📸 Screenshots (optional)

Please provide some screenshot for relevant changes

### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
