### PR TITLE
fix:#621 - fixed admin create entry prompt

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -7,7 +7,7 @@
     </q-card-section>
     <q-card-section class="q-pt-none">
       <q-form @submit.prevent="onSubmit()">
-        <q-select data-test="select-author" :disable="!userStore.isAdmin" label="Author" :options="authorOptions" v-model="entry.author" />
+        <q-select data-test="select-author" disable label="Author" :options="authorOptions" v-model="entry.author" />
         <q-select
           behavior="menu"
           counter

--- a/src/components/Admin/PromptCard.vue
+++ b/src/components/Admin/PromptCard.vue
@@ -40,13 +40,7 @@
                 </template>
               </q-input>
             </div>
-            <q-select
-              data-test="select-author"
-              :disable="!userStore.isAdmin"
-              label="Author"
-              :options="authorOptions"
-              v-model="prompt.author"
-            />
+            <q-select data-test="select-author" disable label="Author" :options="authorOptions" v-model="prompt.author" />
             <q-input
               counter
               data-test="input-title"


### PR DESCRIPTION
### 🛠 Description
Admins should not be allowed to create prompts or entries on behalf on other users, as there is no current use case for this feature. Prompts/entries should only be create on behalf of the current user.

Fixes #621 
I disabled the `Select Author` field, and this field is automatically set to the current user in the prompt and entry creation form.
### ✨ Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
### 🧠 Rationale behind the change
--
### 🧪 All Test Suites Passed?
- [x] Manual tested
- [x] Vitest
- [ ] Cypress
### 🏎 Quick checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
