### PR TITLE
feat:#642 - implement default initials profile pic

### DIFF
--- a/src/pages/PublicProfilePage.vue
+++ b/src/pages/PublicProfilePage.vue
@@ -6,7 +6,14 @@
         <q-card-section class="flex items-center">
           <div class="flex items-center q-gutter-x-md">
             <q-avatar size="7rem">
-              <q-img :src="user.photoURL" />
+              <template v-if="user.photoURL">
+                <q-img :src="user.photoURL" />
+              </template>
+              <template v-else>
+                <span class="q-avatar__content flex flex-center q-mx-auto bg-primary text-white">
+                  {{ user.displayName.charAt(0).toUpperCase() }}
+                </span>
+              </template>
             </q-avatar>
             <h5 class="q-my-none" data-test="user-displayName">{{ user.displayName }}</h5>
           </div>


### PR DESCRIPTION
### 🛠 Description
When a user does not upload a profile picture, the profile picture field should display the initials of the user (e.g., "J" for John Doe) instead of remaining blank.
Fixes #642 

### ✨ Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change
--

### 🧪 All Test Suites Passed?

- [x] Manual tested
- [x] Vitest
- [ ] Cypress

### 📸 Screenshots (optional)

![Screenshot from 2024-10-19 11-38-13](https://github.com/user-attachments/assets/db69bc09-9f50-4a98-b95a-6feb6f0335b6)


### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
