### PR TITLE
fix:#660 - Fixed main menu admin table remain active

### DIFF
--- a/src/pages/admin/AdminIndex.vue
+++ b/src/pages/admin/AdminIndex.vue
@@ -78,7 +78,7 @@ import EntryCard from 'src/components/Admin/EntryCard.vue'
 import PromptCard from 'src/components/Admin/PromptCard.vue'
 import AdvertiseCard from 'src/components/Advertiser/AdvertiseCard.vue'
 import TheHeader from 'src/components/shared/TheHeader.vue'
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, ref, watch, onUnmounted } from 'vue'
 import { useUserStore, useAdvertiseStore, useErrorStore } from 'src/stores'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -145,4 +145,12 @@ function openAdvertiseDialog(props) {
   advertise.value = props?.id ? props : {}
   advertise.value.dialog = true
 }
+
+onUnmounted(async () => {
+  const adminTab = document.querySelector('.adminTab')
+  const activeHomeTab = document.querySelector('[href="/"]')
+  activeHomeTab?.classList.remove('q-tab--inactive')
+  adminTab?.classList.remove('admin_tab', 'cursor-pointer', 'q-router-link--active')
+  adminTab?.classList.replace('q-tab--active', 'q-tab--inactive')
+})
 </script>


### PR DESCRIPTION
### 🛠 Description
This PR addresses the issue where both the Admin Panel and the newly selected tab remained active in the main menu when navigating to another tab.

**Fix Implemented:**

Ensured that the active state of the previously selected tab is removed when a new tab is clicked.
Updated the menu logic to maintain only the currently selected tab as active.

Fixes #660 

### ✨ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change
--

### 🧪 All Test Suites Passed?

- [x] Manual tested
- [ ] Vitest
- [x] Cypress
- Verified that switching between tabs updates the active state correctly.
- Tested edge cases, including rapid switching between tabs and navigating back to the Admin Panel.
### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
