### PR TITLE
fix:#662 - Fixed advertisement status incorrectly show budget crossed

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -55,8 +55,11 @@ async function updateAdvertiseStatus(docId) {
   const totalImpressions = await calculateTotalImpressions(advertiseDocRef)
   const totalClicks = await calculateTotalClicks(advertiseDocRef)
   const totalVisits = await calculateTotalVisits(advertiseDocRef)
+  const impressionsMatic = totalImpressions * 0.001
+  const clicksMatic = totalClicks * 0.001
+  const viewsMatic = totalVisits * 0.001
+  const totalCost = viewsMatic + clicksMatic + impressionsMatic
 
-  const totalCost = totalImpressions / 100 + totalClicks / 20 + totalVisits / 20
   const date1 = new Date()
   const date2 = new Date(docData.endDate)
   date1.setHours(0, 0, 0, 0)


### PR DESCRIPTION
### 🛠 Description

Previously, it was calculated as 1 MATIC for every 20 clicks, 1 MATIC for every 20 visits, and 1 MATIC for every 100 impressions on cloud functions. As a result, it was expiring too quickly.

Fixes #662

Now, it is calculated as 1 MATIC for every 1000 clicks, visits, or impressions.

### ✨ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🧪 All Test Suites Passed?

- [x] Manual tested
- [ ] Vitest
- [x] Cypress

### 📸 Screenshots (optional)


### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
