### PR TITLE
fix:#667 - Fixed load more button visible

### DIFF
--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -46,7 +46,13 @@
       </TransitionGroup>
       <div v-if="showHasMore" class="row justify-center q-mt-md">
         <q-spinner v-if="promptStore.isLoading && promptStore.getPrompts?.length" color="primary" size="70px" :thickness="5" />
-        <q-btn v-else @click="loadMorePrompts" label="Load More" data-test="load-more-btn" color="primary" />
+        <q-btn
+          v-else-if="promptStore.getPrompts?.length"
+          @click="loadMorePrompts"
+          label="Load More"
+          data-test="load-more-btn"
+          color="primary"
+        />
       </div>
     </q-page>
   </q-page-container>

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -113,10 +113,9 @@ export const usePromptStore = defineStore('prompts', {
 
         if (newPrompts.length > 0) {
           this._lastVisible = querySnapshot.docs[querySnapshot.docs.length - 1]
-          this._hasMore = true
-        } else {
-          this._hasMore = false
         }
+        if (newPrompts.length > 4) this._hasMore = true
+        else this._hasMore = false
 
         this._prompts = loadMore ? [...(this._prompts || []), ...newPrompts] : newPrompts
 


### PR DESCRIPTION
### 🛠 Description
This PR resolves the issue where the "Load More" button was visible even after loading the last prompt or entry in the Search Page, Manage Prompt and Entry Table.

**Fix Details**
Added a condition to check if the last prompt or entry has been loaded.
Ensured the "Load More" button is hidden once all data is loaded.
Updated relevant components for consistent behavior across the Search Page, Manage Prompt Table, and Manage Entry Table.

Fixes #667 

### ✨ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change
--

### 🧪 All Test Suites Passed?

- [x] Manual tested
- [ ] Vitest
- [x] Cypress
- Verified the "Load More" button does not appear when the last prompt/entry is loaded.
- Ensured clicking the button (if visible) does not cause unexpected behavior.
- Tested on all affected pages to confirm consistent functionality.

### 📸 Screenshots (optional)


### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
