### PR TITLE
fix:#715 - fixed image height for prompt arts carousel

### DIFF
--- a/src/components/Posts/ShowcaseArt.vue
+++ b/src/components/Posts/ShowcaseArt.vue
@@ -25,7 +25,7 @@
       >
         <q-img class="rounded-borders" fit="contain" :src="art" @click.stop="openDialog = true" />
       </q-carousel-slide>
-      <q-carousel-slide v-if="showcase.artist.info" class="q-pa-none" :name="showcase?.arts.length">
+      <q-carousel-slide v-if="showcase.artist.info" class="q-pa-none" :name="showcase?.arts.length" style="max-height: 450px">
         <q-img v-if="showcase.artist.photo" class="col-sm-6 col-xs-12 rounded-borders" :src="showcase.artist.photo" />
         <p class="col-sm-6 col-xs-12 flex items-center q-pa-md">{{ showcase.artist.info }}</p>
       </q-carousel-slide>

--- a/src/components/Posts/ShowcaseArt.vue
+++ b/src/components/Posts/ShowcaseArt.vue
@@ -21,6 +21,7 @@
         class="flex justify-center q-pa-none cursor-pointer"
         :key="index"
         :name="index"
+        style="max-height: 450px"
       >
         <q-img class="rounded-borders" fit="contain" :src="art" @click.stop="openDialog = true" />
       </q-carousel-slide>
@@ -50,7 +51,7 @@
       <q-carousel-slide v-if="showcase.artist.info" class="q-pa-none" :name="showcase?.arts.length">
         <q-img v-if="!!showcase.artist.photo" class="col-sm-6 col-xs-12 rounded-borders" :src="showcase.artist.photo" />
         <div class="col-sm-6 col-xs-12 flex items-center q-px-xl q-py-md">
-          <p style="border: 1px solid gray; width: 100%; border-radius: 8px; padding: 8px">{{ showcase.artist.info }}</p>
+          <p style="width: 100%; padding: 8px">{{ showcase.artist.info }}</p>
         </div>
       </q-carousel-slide>
     </q-carousel>


### PR DESCRIPTION
### 🛠 Description
Fixed image height for prompts art carousel
Removed border for artist info

Fixes #715 

### ✨ Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### 🧪 All Test Suites Passed?

- [X] Manual tested
- [X] Cypress

### 📸 Screenshots (optional)
<img width="681" alt="Screenshot 2025-03-02 at 12 16 39" src="https://github.com/user-attachments/assets/5c4a777f-a119-4bdf-a93c-f55b41b6b937" />

Please provide some screenshot for relevant changes

### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
