### PR TITLE
feat:#719 - prompts entries and ads drafts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/vue-query-devtools": "^5.51.21",
         "@web3modal/ethers5": "^4.2.3",
         "big-integer": "^1.6.52",
+        "dexie": "^4.0.11",
         "dotenv": "^16.3.1",
         "echarts": "^5.4.3",
         "eslint-plugin-prettier": "^5.2.1",
@@ -10939,6 +10940,11 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true
+    },
+    "node_modules/dexie": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A=="
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@tanstack/vue-query-devtools": "^5.51.21",
     "@web3modal/ethers5": "^4.2.3",
     "big-integer": "^1.6.52",
+    "dexie": "^4.0.11",
     "dotenv": "^16.3.1",
     "echarts": "^5.4.3",
     "eslint-plugin-prettier": "^5.2.1",

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -240,7 +240,12 @@ watch(
 const promptOptions = computed(
   () =>
     promptStore._activePrompts
-      ?.map((prompt) => ({ label: `${prompt.date} – ${prompt.title}`, value: prompt.date, escrowId: prompt.escrowId }))
+      ?.map((prompt) => ({
+        label: `${prompt.date || prompt.publicationDate} – ${prompt.title}`,
+        value: prompt.id,
+        escrowId: prompt.escrowId,
+        date: prompt.date || prompt.creationDate
+      }))
       .reverse() || []
 )
 

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -126,6 +126,7 @@
               v-model:artist="entry.showcase.artist"
               @updateRecentUploads="updateRecentUploadsRef"
               @updateRecentArtistImage="updateRecentArtistImageRef"
+              @update:artsToRemove="imagesToRemoveList"
             />
           </q-step>
 
@@ -159,7 +160,7 @@
                   data-test="button-submit"
                   :disable="!entry.title || !entry.description || !entry.prompt || !entry.image"
                   :label="id ? 'Save Edits' : 'Submit Entry'"
-                  :loading="promptStore.isLoading || storageStore.isLoading"
+                  :loading="entryStore.isLoading || storageStore.isLoading"
                   rounded
                   type="submit"
                 >
@@ -196,8 +197,6 @@
 import { useQuasar } from 'quasar'
 import { computed, onMounted, ref, toRaw, watch, watchEffect } from 'vue'
 import { useEntryStore, useErrorStore, usePromptStore, useUserStore, useStorageStore } from 'src/stores'
-
-import { useRouter } from 'vue-router'
 import CaptureCamera from '../shared/CameraCapture.vue'
 import ShowcaseCard from 'components/Admin/ShowcaseCard.vue'
 import { indexedDb } from 'src/utils/indexeddb'
@@ -254,6 +253,10 @@ watch(
   { immediate: true }
 )
 
+const imagesToRemoveList = (e) => {
+  entry.value.artsToRemove = [...e]
+}
+
 const promptOptions = computed(
   () =>
     promptStore._activePrompts
@@ -277,7 +280,7 @@ async function loadEntryFromDexie() {
 }
 
 onMounted(async () => {
-  promptStore.activePromptsListener()
+  await promptStore.activePromptsListener()
   await loadEntryFromDexie()
   if (parsedEntry.value && !props.id) {
     entry.value = {
@@ -400,7 +403,6 @@ async function onSubmit() {
   const failureMessage = props.id ? 'Entry edit failed' : 'Entry submission failed'
 
   try {
-    // throw new Error('')
     await action(entry.value)
 
     if (props.id) {

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -74,7 +74,7 @@
                     ['undo', 'redo']
                   ]"
                   v-model="entry.description"
-                  @paste="onPaste($event)"
+                  @paste="handlePaste($event)"
                 />
               </template>
             </q-field>
@@ -85,12 +85,11 @@
                   counter
                   data-test="file-image"
                   :disable="!entry.prompt"
-                  :hint="!entry.prompt ? 'Select prompt first' : !entry.image ? '*Image is required. Max size is 2MB.' : ''"
+                  :hint="!entry.prompt ? 'Select prompt first' : !entry.image ? '*Image is required. Max size is 2MB.' : 'Image loaded'"
                   label="Image"
                   :max-total-size="2097152"
-                  :required="!id"
-                  use-chips
-                  v-model="imageModel"
+                  :required="!id && !entry.image"
+                  v-model="uploadedImage"
                   @rejected="onRejected()"
                   @update:model-value="uploadPhoto()"
                 >
@@ -143,7 +142,7 @@
                   flat
                   rounded
                   label="Cancel"
-                  @click="handleDeleteImagesOnCancel"
+                  @click="() => {}"
                   v-close-popup
                   :disable="promptStore.isLoading"
                   data-test="cancel-button"
@@ -151,12 +150,7 @@
                 <q-btn
                   color="primary"
                   data-test="button-submit"
-                  :disable="
-                    !entry.title ||
-                    !entry.description ||
-                    // !entry.image ||
-                    entryStore.isLoading
-                  "
+                  :disable="!entry.title || !entry.description || !entry.image || entryStore.isLoading"
                   :label="id ? 'Save Edits' : 'Submit Entry'"
                   :loading="entryStore.isLoading || entryStore.isLoading"
                   rounded
@@ -191,13 +185,13 @@
 </template>
 
 <script setup>
-import { LocalStorage, useQuasar } from 'quasar'
-import { useEntryStore, useErrorStore, usePromptStore, useStorageStore, useUserStore } from 'src/stores'
-import { computed, onMounted, reactive, ref, watch, watchEffect } from 'vue'
-import { uploadAndSetImage } from 'src/utils/imageConvertor'
-import { useRouter } from 'vue-router'
+import { useQuasar } from 'quasar'
+import { useEntryStore, useErrorStore, usePromptStore, useUserStore } from 'src/stores'
+import { computed, onMounted, reactive, ref, toRaw, watch, watchEffect } from 'vue'
 import CaptureCamera from '../shared/CameraCapture.vue'
 import ShowcaseCard from 'components/Admin/ShowcaseCard.vue'
+import { onPaste } from 'src/utils/helpers'
+import { indexedDb } from 'src/utils/indexeddb'
 
 const emit = defineEmits(['hideDialog'])
 const props = defineProps(['author', 'created', 'description', 'id', 'image', 'prompt', 'slug', 'title', 'selectedPromptDate', 'showcase'])
@@ -206,36 +200,25 @@ const $q = useQuasar()
 const entryStore = useEntryStore()
 const errorStore = useErrorStore()
 const promptStore = usePromptStore()
-const storageStore = useStorageStore()
 const userStore = useUserStore()
-const router = useRouter()
-const { href } = router.currentRoute.value
 const step = ref(1)
 const editorRef = ref(null)
-const entry = reactive({
+const entry = ref({
   author: { label: userStore.getUser.displayName, value: userStore.getUser.uid },
   description: '',
-  image: '',
-  showcase: { arts: [], artist: { info: '', photo: '' } },
-  title: ''
+  showcase: { arts: [], artist: { info: '', photo: '', file: null } },
+  title: '',
+  prompt: null,
+  image: null,
+  imageFile: null,
+  imagePath: null
 })
-
-const imageModel = ref([])
+const uploadedImage = ref(null)
 const openCamera = ref(false)
 const todayDate = new Date().toISOString().replace(/[.:-]/g, '')
-const uploadedImages = ref([])
 const recentUploadsRef = ref([])
 const recentArtistImage = ref('')
-const entryFromLocalStorage = LocalStorage.getItem('entry')
-const parsedEntry = reactive(JSON.parse(entryFromLocalStorage) || undefined)
-
-watch(
-  () => entry.showcase.arts,
-  (newArts) => {
-    uploadedImages.value = newArts.map((art) => art.image)
-  },
-  { deep: true }
-)
+const parsedEntry = ref(null)
 
 const promptOptions = computed(
   () =>
@@ -249,73 +232,66 @@ const promptOptions = computed(
       .reverse() || []
 )
 
-onMounted(() => {
-  promptStore.activePromptsListener()
-})
-
-watchEffect(() => {
-  if (parsedEntry && !props.id) {
-    entry.author = { label: parsedEntry?.author.label, value: parsedEntry?.author.value }
-    entry.description = parsedEntry?.description
-    entry.showcase = parsedEntry?.showcase
-    entry.title = parsedEntry?.title
-    entry.prompt = parsedEntry.prompt
-  } else if (props.id) {
-    entry.author = { label: props.author?.displayName, value: props.author?.uid }
-    entry.description = props.description
-    entry.image = props.image
-    entry.prompt = { label: `${props.prompt.date} – ${props.prompt.title}`, value: props.prompt.date }
-    entry.title = props.title
-    entry.showcase = props.showcase
-  } else if (props.selectedPromptDate) {
-    entry.prompt = promptOptions.value.find((prompt) => prompt.value === props.selectedPromptDate)
+async function loadEntryFromDexie() {
+  try {
+    const entries = await indexedDb.entry.toArray()
+    parsedEntry.value = entries[entries.length - 1] || null
+  } catch (error) {
+    console.error('Failed to load entries from Dexie:', error)
+    parsedEntry.value = null
   }
-})
-
-function uploadPhoto() {
-  entry.image = ''
-  if (!imageModel.value) {
-    return
-  }
-  const reader = new FileReader()
-  reader.readAsDataURL(imageModel.value)
-  reader.onload = () => (entry.image = reader.result)
 }
+onMounted(async () => {
+  await loadEntryFromDexie()
+  if (parsedEntry.value && !props.id) {
+    entry.value = {
+      ...entry.value,
+      ...parsedEntry.value,
+      author: userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
+    }
+    if (parsedEntry.value.imageFile instanceof Blob) {
+      entry.value.image = URL.createObjectURL(parsedEntry.value.imageFile)
+      uploadedImage.value = parsedEntry.value.imageFile
+    }
+  } else if (props.id) {
+    entry.value = {
+      ...props,
+      author: { label: props.author.displayName, value: props.author.uid },
+      prompt: { label: `${props.prompt.date || props.prompt.publicationDate} – ${props.prompt.title}`, value: props.prompt.id }
+    }
+  }
+  await promptStore.activePromptsListener()
+})
 
 function onRejected() {
   $q.notify({ type: 'negative', message: `Image did not pass validation constraints` })
 }
 
-function onPaste(evt) {
-  // Let inputs do their thing, so we don't break pasting of links.
-  if (evt.target.nodeName === 'INPUT') return
-  let text, onPasteStripFormattingIEPaste
-  evt.preventDefault()
-  evt.stopPropagation()
-  if (evt.originalEvent && evt.originalEvent.clipboardData.getData) {
-    text = evt.originalEvent.clipboardData.getData('text/plain')
-    editorRef.value.runCmd('insertText', text)
-  } else if (evt.clipboardData && evt.clipboardData.getData) {
-    text = evt.clipboardData.getData('text/plain')
-    editorRef.value.runCmd('insertText', text)
-  } else if (window.clipboardData && window.clipboardData.getData) {
-    if (!onPasteStripFormattingIEPaste) {
-      onPasteStripFormattingIEPaste = true
-      editorRef.value.runCmd('ms-pasteTextOnly', text)
-    }
-    onPasteStripFormattingIEPaste = false
+function handlePaste(event) {
+  if (!editorRef.value) {
+    const unwatch = watch(
+      () => editorRef.value,
+      (newVal) => {
+        if (newVal) {
+          onPaste(event, editorRef)
+          unwatch()
+        }
+      }
+    )
+  } else {
+    onPaste(event, editorRef)
   }
 }
 
 async function onSubmit() {
-  entry.title = entry.title.trim()
-  const hasLoadedEntry = entryStore.checkPromptRelatedEntry(entry.prompt?.value)
+  entry.value.title = entry.value.title.trim()
+  const hasLoadedEntry = entryStore.checkPromptRelatedEntry(entry.value.prompt?.value)
 
   if (!hasLoadedEntry) {
-    await entryStore.fetchEntryByPrompts(entry.prompt?.value)
+    await entryStore.fetchEntryByPrompts(entry.value.prompt?.value)
   }
 
-  const hasEntry = entryStore.hasEntry(entry.prompt?.value)
+  const hasEntry = entryStore.hasEntry(entry.value.prompt?.value)
 
   if (!props.id && hasEntry) {
     $q.notify({
@@ -325,90 +301,119 @@ async function onSubmit() {
     return
   }
 
-  const entryNameValidator = entryStore.entryNameValidator(props.id, entry.prompt?.value, entry.title, !!props.id)
-
-  if (entryNameValidator) {
+  const titleExists = entryStore.entryNameValidator(props.id, entry.value.prompt?.value, entry.value.title, !!props.id)
+  if (titleExists) {
     $q.notify({ message: 'Entry with this title already exists. Please choose another title.', type: 'negative' })
     return
   }
-  entry.slug = `/${entry.prompt.value.replace(/\-/g, '/')}/${entry.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')}`
-  entry.id = props.id || `${entry.prompt?.value}T${Date.now()}`
 
-  if (Object.keys(imageModel.value ?? {}).length || imageModel.value?.type) {
-    entry.image = await uploadAndSetImage(imageModel.value, `images/entry-${entry.id}`)
-  } else {
-    entry.image = props.image
-  }
+  const date = props.id ? props.prompt.date || props.prompt.publicationDate : entry.value.prompt.date
+  entry.value.slug = `/${date.replace(/\-/g, '/')}/${entry.value.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')}`
+  entry.value.id = props.id || `${entry.value.prompt?.value}T${Date.now()}`
 
   const action = props.id ? entryStore.editEntry : entryStore.addEntry
   const successMessage = props.id ? 'Entry successfully edited' : 'Entry successfully submitted'
   const failureMessage = props.id ? 'Entry edit failed' : 'Entry submission failed'
 
   try {
-    await action(entry)
+    // throw new Error('')
+    await action(entry.value)
+
     if (props.id) {
       await entryStore.fetchUserRelatedEntries(userStore.getUserId)
     }
-    if (href.includes('/admin') && !userStore.isEditorOrAbove) {
-      await entryStore.fetchUserRelatedEntries(userStore.getUserId)
-    } else {
-      const updatedPrompt = await promptStore.fetchPromptById(entry.prompt.value)
-      const updatedList = updatedPrompt.find((prompt) => prompt.id === entry.prompt.value).entries
-      const res = await entryStore.fetchPromptsEntries(updatedList)
-      const loadedPrompt = entryStore._loadedEntries.find((el) => el.promptId === entry.prompt.value)
 
-      if (loadedPrompt) {
-        const emptyList = !loadedPrompt.entries.length
-        loadedPrompt.entries = res
-        emptyList && (await promptStore.fetchPrompts())
-      }
-    }
     $q.notify({ type: 'positive', message: successMessage })
-    if (parsedEntry) {
-      LocalStorage.remove('entry')
-    }
+    emit('hideDialog', entry.value.slug)
+    indexedDb.entry?.clear()
   } catch (e) {
-    LocalStorage.set('entry', JSON.stringify(entry))
-    handleDeleteImagesOnCancel()
-    await storageStore.deleteFile(`images/entry-${entry.id}`)
+    const entryToSave = {
+      author: toRaw(entry.value.author),
+      description: entry.value.description,
+      showcase: toRaw(entry.value.showcase),
+      title: entry.value.title,
+      prompt: toRaw(entry.value.prompt),
+      imagePath: entry.value.imagePath,
+      slug: entry.value.slug,
+      id: entry.value.id
+    }
+    if (parsedEntry.value && parsedEntry.value.id) {
+      await indexedDb.entry.update(parsedEntry.value.id, entryToSave)
+    } else if (!props.id) {
+      await indexedDb.entry.add({
+        ...entryToSave,
+        imageFile: entry.value.imageFile
+      })
+    }
+    emit('hideDialog', entry.value.slug)
+
+    parsedEntry.value = { ...entry }
     await errorStore.throwError(e, failureMessage)
   }
-  emit('hideDialog', entry.slug)
+}
+
+// ----- Image selection / uploading ----- \\
+async function uploadPhoto() {
+  if (!uploadedImage.value) {
+    if (entry.value.image && !entry.value.imagePath) {
+      URL.revokeObjectURL(entry.value.image)
+    }
+    entry.value.image = null
+    entry.value.imageFile = null
+    return
+  }
+
+  if (uploadedImage.value instanceof Blob) {
+    if (entry.value.image && !entry.value.imagePath) {
+      URL.revokeObjectURL(entry.value.image)
+    }
+
+    entry.value.imageFile = uploadedImage.value
+    entry.value.image = URL.createObjectURL(entry.value.imageFile)
+    if (parsedEntry.value) {
+      parsedEntry.value.image = URL.createObjectURL(entry.value.imageFile)
+    }
+    // UPDATE INDEXEDDB IMAGE IF IT EXISTS
+    if (parsedEntry.value && parsedEntry.value.id) {
+      await indexedDb.entry.update(parsedEntry.value.id, {
+        image: entry.value.image,
+        imageFile: entry.value.imageFile
+      })
+      parsedEntry.value.image = entry.value.image
+      parsedEntry.value.imageFile = entry.value.imageFile
+    }
+  }
 }
 
 function captureCamera(imageBlob) {
-  imageModel.value = imageBlob
+  uploadedImage.value = imageBlob
   uploadPhoto()
-}
-
-function handleDeleteImagesOnCancel() {
-  if (!!recentArtistImage.value.length) {
-    storageStore.deleteFile(recentArtistImage.value)
-    entry.showcase.artist.photo = null
-  }
-
-  storageStore.deleteMultipleFiles(entry.showcase.arts.length ? recentUploadsRef.value : entry.showcase.arts)
-  entry.showcase.arts = entry.showcase.arts.filter((item) => {
-    return !recentUploadsRef.value.includes(item)
-  })
 }
 
 function updateRecentUploadsRef(updatedArts) {
   recentUploadsRef.value.push(updatedArts)
 }
+
 function updateRecentArtistImageRef(artistImage) {
   recentArtistImage.value = artistImage
 }
 
 function resetEntry() {
-  LocalStorage.remove('entry')
-  parsedEntry.title = ''
-  parsedEntry.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
-  parsedEntry.description = ''
-  parsedEntry.image = null
-  parsedEntry.prompt = null
-  parsedEntry.showcase = { arts: [], artist: { info: '', photo: '' } }
+  indexedDb.entry?.clear()
+  parsedEntry.value = null
+  entry.value.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
+  entry.value.description = ''
+  entry.value.title = ''
+  entry.value.image = null
+  entry.value.prompt = null
+  entry.value.showcase = { arts: [], artist: { info: '', photo: '', file: null } }
+  if (entry.value.image && !entry.value.imagePath) {
+    URL.revokeObjectURL(entry.value.image)
+  }
+  entry.value.image = null
+  entry.value.imageFile = null
+  uploadedImage.value = null
 
-  $q.notify({ type: 'info', message: 'Prompt has been reset.' })
+  $q.notify({ type: 'info', message: 'Entry has been reset.' })
 }
 </script>

--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -3,141 +3,184 @@
     <q-card-section class="row items-baseline no-wrap">
       <h2 class="q-my-none text-h6">{{ id ? 'Edit Entry' : 'New Entry' }}</h2>
       <q-space />
-      <q-btn flat round icon="close" v-close-popup />
+      <q-btn flat round icon="close" @click="handleDeleteImagesOnCancel" v-close-popup data-test="close-button" />
     </q-card-section>
     <q-card-section class="q-pt-none">
       <q-form @submit.prevent="onSubmit()">
-        <q-select data-test="select-author" disable label="Author" v-model="entry.author" />
-        <q-select
-          behavior="menu"
-          counter
-          data-test="select-prompt"
-          :disable="Boolean(entry.id)"
-          :hint="entry.image ? 'Image is attached to this prompt' : ''"
-          label="Prompt"
-          :options="promptOptions"
-          use-chips
-          :rules="[(val) => val || 'Please select the related prompt']"
-          v-model="entry.prompt"
-        >
-          <template v-slot:no-option>
-            <q-item>
-              <q-item-section class="text-grey">No results</q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-        <q-input
-          counter
-          data-test="input-title"
-          label="Title"
-          maxlength="80"
-          required
-          v-model="entry.title"
-          :disable="!entry.prompt"
-          :hint="!entry.prompt ? 'Select prompt first' : !entry.title ? '*Title is required' : ''"
-        />
-        <q-field
-          counter
-          label="Description"
-          maxlength="400"
-          v-model="entry.description"
-          :hint="!entry.description ? '*Description is required' : ''"
-        >
-          <template v-slot:control>
-            <q-editor
-              class="q-mt-md"
-              data-test="input-description"
-              dense
-              flat
-              min-height="5rem"
-              ref="editorRef"
-              style="width: 100%"
-              :toolbar="[
-                [
-                  {
-                    icon: $q.iconSet.editor.align,
-                    options: ['left', 'center', 'right', 'justify']
-                  },
-                  {
-                    icon: $q.iconSet.editor.fontSize,
-                    list: 'no-icons',
-                    options: ['size-1', 'size-2', 'size-3', 'size-4', 'size-5', 'size-6', 'size-7']
-                  },
-                  {
-                    icon: $q.iconSet.editor.formatting,
-                    options: ['bold', 'italic', 'strike', 'underline', 'subscript', 'superscript', 'quote', 'unordered', 'ordered']
-                  },
-                  ['link']
-                ],
-                ['undo', 'redo']
-              ]"
-              v-model="entry.description"
-              @paste="onPaste($event)"
-            />
-          </template>
-        </q-field>
-
-        <div class="row no-wrap">
-          <div class="col-9">
-            <q-file
-              accept=".jpg, image/*"
+        <q-stepper alternative-labels animated color="primary" header-nav v-model="step">
+          <q-step icon="settings" :name="1" :title="id ? 'Edit Entry' : 'New Entry'">
+            <q-select data-test="select-author" disable label="Author" v-model="entry.author" />
+            <q-select
+              behavior="menu"
               counter
-              data-test="file-image"
-              :disable="!entry.prompt"
-              :hint="!entry.prompt ? 'Select prompt first' : !entry.image ? '*Image is required. Max size is 2MB.' : ''"
-              label="Image"
-              :max-total-size="2097152"
-              :required="!id"
+              data-test="select-prompt"
+              :disable="Boolean(entry.id)"
+              :hint="entry.image ? 'Image is attached to this prompt' : ''"
+              label="Prompt"
+              :options="promptOptions"
               use-chips
-              class="full-width"
-              v-model="imageModel"
-              @rejected="onRejected()"
-              @update:model-value="uploadPhoto()"
+              :rules="[(val) => val || 'Please select the related prompt']"
+              v-model="entry.prompt"
             >
-              <template v-slot:append>
-                <q-icon name="image" />
+              <template v-slot:no-option>
+                <q-item>
+                  <q-item-section class="text-grey">No results</q-item-section>
+                </q-item>
               </template>
-            </q-file>
-          </div>
-          <div class="col-1 flex justify-center items-center"><p>OR</p></div>
-          <q-btn
-            :disable="!entry.prompt"
-            color="primary"
-            icon="add_a_photo"
-            class="self-center col"
-            label="Capture Image"
-            @click="openCamera = true"
-          ></q-btn>
-        </div>
-        <div class="text-center">
-          <q-img v-if="entry.image" class="q-mt-md" :src="entry.image" fit="contain" style="max-height: 40vh; max-width: 80vw" />
-        </div>
-        <q-btn
-          class="full-width q-mt-xl"
-          color="primary"
-          data-test="button-submit"
-          :disable="!entry.title || !entry.description || !entry.prompt || !entry.image"
-          :label="id ? 'Save Edits' : 'Submit Entry'"
-          :loading="promptStore.isLoading || storageStore.isLoading"
-          rounded
-          type="submit"
-        >
-          <q-tooltip
-            v-if="!entry.title || !entry.description || !entry.prompt || !entry.image"
-            class="text-center"
-            style="white-space: pre-line"
-          >
-            {{
-              !entry.title || !entry.description
-                ? 'Please make sure you have a title and description'
-                : !entry.prompt
-                  ? 'Please select a prompt'
-                  : !entry.image
-                    ? 'Please select an image'
-                    : 'Please make sure all fields are filled'
-            }}
-          </q-tooltip>
-        </q-btn>
+            </q-select>
+            <q-input
+              counter
+              data-test="input-title"
+              label="Title"
+              maxlength="80"
+              required
+              v-model="entry.title"
+              :disable="!entry.prompt"
+              :hint="!entry.prompt ? 'Select prompt first' : !entry.title ? '*Title is required' : ''"
+            />
+            <q-field
+              counter
+              label="Description"
+              maxlength="400"
+              v-model="entry.description"
+              :hint="!entry.description ? '*Description is required' : ''"
+            >
+              <template v-slot:control>
+                <q-editor
+                  class="q-mt-md"
+                  data-test="input-description"
+                  dense
+                  flat
+                  min-height="5rem"
+                  ref="editorRef"
+                  style="width: 100%"
+                  :toolbar="[
+                    [
+                      {
+                        icon: $q.iconSet.editor.align,
+                        options: ['left', 'center', 'right', 'justify']
+                      },
+                      {
+                        icon: $q.iconSet.editor.fontSize,
+                        list: 'no-icons',
+                        options: ['size-1', 'size-2', 'size-3', 'size-4', 'size-5', 'size-6', 'size-7']
+                      },
+                      {
+                        icon: $q.iconSet.editor.formatting,
+                        options: ['bold', 'italic', 'strike', 'underline', 'subscript', 'superscript', 'quote', 'unordered', 'ordered']
+                      },
+                      ['link']
+                    ],
+                    ['undo', 'redo']
+                  ]"
+                  v-model="entry.description"
+                  @paste="onPaste($event)"
+                />
+              </template>
+            </q-field>
+            <div class="flex justify-between items-center">
+              <div class="">
+                <q-file
+                  accept=".jpg, image/*"
+                  counter
+                  data-test="file-image"
+                  :disable="!entry.prompt"
+                  :hint="!entry.prompt ? 'Select prompt first' : !entry.image ? '*Image is required. Max size is 2MB.' : ''"
+                  label="Image"
+                  :max-total-size="2097152"
+                  :required="!id"
+                  use-chips
+                  v-model="imageModel"
+                  @rejected="onRejected()"
+                  @update:model-value="uploadPhoto()"
+                >
+                  <template v-slot:append>
+                    <q-icon name="image" />
+                  </template>
+                </q-file>
+              </div>
+              <q-btn
+                style="max-height: 20px"
+                :disable="!entry.prompt"
+                color="primary"
+                icon="add_a_photo"
+                label="Capture Image"
+                @click="openCamera = true"
+              ></q-btn>
+            </div>
+            <div class="text-center">
+              <q-img v-if="entry.image" class="q-mt-md" :src="entry.image" fit="contain" style="max-height: 40vh; max-width: 80vw" />
+            </div>
+          </q-step>
+          <q-step caption="Optional" :done="step > 2" icon="create_new_folder" :name="2" title="Artist Carousel">
+            <ShowcaseCard
+              collectionName="entry"
+              :date="todayDate"
+              v-model:arts="entry.showcase.arts"
+              v-model:artist="entry.showcase.artist"
+              @updateRecentUploads="updateRecentUploadsRef"
+              @updateRecentArtistImage="updateRecentArtistImageRef"
+            />
+          </q-step>
+
+          <template v-slot:navigation>
+            <q-stepper-navigation class="flex justify-end q-gutter-md">
+              <template v-if="promptStore.isLoading">
+                <q-skeleton type="rect" class="q-mr-md" style="height: 40px; width: 100px" />
+                <q-skeleton type="rect" class="q-mr-md" style="height: 40px; width: 120px" />
+              </template>
+              <template v-else>
+                <q-btn
+                  flat
+                  rounded
+                  label="Reset"
+                  @click="resetEntry"
+                  v-if="parsedEntry?.title"
+                  :disable="promptStore.isLoading"
+                  data-test="reset-button"
+                />
+                <q-btn
+                  flat
+                  rounded
+                  label="Cancel"
+                  @click="handleDeleteImagesOnCancel"
+                  v-close-popup
+                  :disable="promptStore.isLoading"
+                  data-test="cancel-button"
+                />
+                <q-btn
+                  color="primary"
+                  data-test="button-submit"
+                  :disable="
+                    !entry.title ||
+                    !entry.description ||
+                    // !entry.image ||
+                    entryStore.isLoading
+                  "
+                  :label="id ? 'Save Edits' : 'Submit Entry'"
+                  :loading="entryStore.isLoading || entryStore.isLoading"
+                  rounded
+                  type="submit"
+                />
+                <q-tooltip
+                  v-if="!entry.title || !entry.description || !entry.prompt || !entry.image"
+                  class="text-center"
+                  style="white-space: pre-line"
+                >
+                  {{
+                    !entry.title || !entry.description
+                      ? 'Please make sure you have a title and description'
+                      : !entry.prompt
+                        ? 'Please select a prompt'
+                        : !entry.image
+                          ? 'Please select an image'
+                          : 'Please make sure all fields are filled'
+                  }}
+                </q-tooltip>
+              </template>
+            </q-stepper-navigation>
+          </template>
+        </q-stepper>
       </q-form>
     </q-card-section>
   </q-card>
@@ -148,15 +191,16 @@
 </template>
 
 <script setup>
-import { useQuasar } from 'quasar'
+import { LocalStorage, useQuasar } from 'quasar'
 import { useEntryStore, useErrorStore, usePromptStore, useStorageStore, useUserStore } from 'src/stores'
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch, watchEffect } from 'vue'
 import { uploadAndSetImage } from 'src/utils/imageConvertor'
 import { useRouter } from 'vue-router'
 import CaptureCamera from '../shared/CameraCapture.vue'
+import ShowcaseCard from 'components/Admin/ShowcaseCard.vue'
 
 const emit = defineEmits(['hideDialog'])
-const props = defineProps(['author', 'created', 'description', 'id', 'image', 'prompt', 'slug', 'title', 'selectedPromptDate'])
+const props = defineProps(['author', 'created', 'description', 'id', 'image', 'prompt', 'slug', 'title', 'selectedPromptDate', 'showcase'])
 
 const $q = useQuasar()
 const entryStore = useEntryStore()
@@ -166,37 +210,58 @@ const storageStore = useStorageStore()
 const userStore = useUserStore()
 const router = useRouter()
 const { href } = router.currentRoute.value
-
+const step = ref(1)
 const editorRef = ref(null)
 const entry = reactive({
   author: { label: userStore.getUser.displayName, value: userStore.getUser.uid },
   description: '',
   image: '',
+  showcase: { arts: [], artist: { info: '', photo: '' } },
   title: ''
 })
+
 const imageModel = ref([])
 const openCamera = ref(false)
+const todayDate = new Date().toISOString().replace(/[.:-]/g, '')
+const uploadedImages = ref([])
+const recentUploadsRef = ref([])
+const recentArtistImage = ref('')
+const entryFromLocalStorage = LocalStorage.getItem('entry')
+const parsedEntry = reactive(JSON.parse(entryFromLocalStorage) || undefined)
+
+watch(
+  () => entry.showcase.arts,
+  (newArts) => {
+    uploadedImages.value = newArts.map((art) => art.image)
+  },
+  { deep: true }
+)
 
 const promptOptions = computed(
   () =>
     promptStore._activePrompts
-      ?.map((prompt) => ({
-        label: `${prompt.date || prompt.publicationDate} – ${prompt.title}`,
-        value: prompt.id,
-        escrowId: prompt.escrowId,
-        date: prompt.date || prompt.creationDate
-      }))
+      ?.map((prompt) => ({ label: `${prompt.date} – ${prompt.title}`, value: prompt.date, escrowId: prompt.escrowId }))
       .reverse() || []
 )
 
 onMounted(() => {
   promptStore.activePromptsListener()
-  if (props.id) {
+})
+
+watchEffect(() => {
+  if (parsedEntry && !props.id) {
+    entry.author = { label: parsedEntry?.author.label, value: parsedEntry?.author.value }
+    entry.description = parsedEntry?.description
+    entry.showcase = parsedEntry?.showcase
+    entry.title = parsedEntry?.title
+    entry.prompt = parsedEntry.prompt
+  } else if (props.id) {
     entry.author = { label: props.author?.displayName, value: props.author?.uid }
     entry.description = props.description
     entry.image = props.image
-    entry.prompt = { label: `${props.prompt.date || props.prompt.publicationDate} – ${props.prompt.title}`, value: props.prompt.id }
+    entry.prompt = { label: `${props.prompt.date} – ${props.prompt.title}`, value: props.prompt.date }
     entry.title = props.title
+    entry.showcase = props.showcase
   } else if (props.selectedPromptDate) {
     entry.prompt = promptOptions.value.find((prompt) => prompt.value === props.selectedPromptDate)
   }
@@ -261,8 +326,7 @@ async function onSubmit() {
     $q.notify({ message: 'Entry with this title already exists. Please choose another title.', type: 'negative' })
     return
   }
-  const date = props.id ? props.prompt.date || props.prompt.publicationDate : entry.prompt.date
-  entry.slug = `/${date.replace(/\-/g, '/')}/${entry.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')}`
+  entry.slug = `/${entry.prompt.value.replace(/\-/g, '/')}/${entry.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')}`
   entry.id = props.id || `${entry.prompt?.value}T${Date.now()}`
 
   if (Object.keys(imageModel.value ?? {}).length || imageModel.value?.type) {
@@ -295,7 +359,13 @@ async function onSubmit() {
       }
     }
     $q.notify({ type: 'positive', message: successMessage })
+    if (parsedEntry) {
+      LocalStorage.remove('entry')
+    }
   } catch (e) {
+    LocalStorage.set('entry', JSON.stringify(entry))
+    handleDeleteImagesOnCancel()
+    await storageStore.deleteFile(`images/entry-${entry.id}`)
     await errorStore.throwError(e, failureMessage)
   }
   emit('hideDialog', entry.slug)
@@ -304,5 +374,36 @@ async function onSubmit() {
 function captureCamera(imageBlob) {
   imageModel.value = imageBlob
   uploadPhoto()
+}
+
+function handleDeleteImagesOnCancel() {
+  if (!!recentArtistImage.value.length) {
+    storageStore.deleteFile(recentArtistImage.value)
+    entry.showcase.artist.photo = null
+  }
+
+  storageStore.deleteMultipleFiles(entry.showcase.arts.length ? recentUploadsRef.value : entry.showcase.arts)
+  entry.showcase.arts = entry.showcase.arts.filter((item) => {
+    return !recentUploadsRef.value.includes(item)
+  })
+}
+
+function updateRecentUploadsRef(updatedArts) {
+  recentUploadsRef.value.push(updatedArts)
+}
+function updateRecentArtistImageRef(artistImage) {
+  recentArtistImage.value = artistImage
+}
+
+function resetEntry() {
+  LocalStorage.remove('entry')
+  parsedEntry.title = ''
+  parsedEntry.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
+  parsedEntry.description = ''
+  parsedEntry.image = null
+  parsedEntry.prompt = null
+  parsedEntry.showcase = { arts: [], artist: { info: '', photo: '' } }
+
+  $q.notify({ type: 'info', message: 'Prompt has been reset.' })
 }
 </script>

--- a/src/components/Admin/ManagePromptsEntries.vue
+++ b/src/components/Admin/ManagePromptsEntries.vue
@@ -179,7 +179,7 @@
       </q-card-section>
       <q-card-actions align="right">
         <q-btn color="primary" flat label="Cancel" v-close-popup />
-        <q-btn color="negative" data-test="confirm-delete-prompt" flat label="Delete" @click="onDeletePrompt(deleteDialog.prompt.id)" />
+        <q-btn color="negative" data-test="confirm-delete-prompt" flat label="Delete" @click="onDeletePrompt(deleteDialog.prompt)" />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -275,9 +275,9 @@ function openDeleteDialog(prompt) {
   deleteDialog.value.prompt = prompt
 }
 
-function onDeletePrompt(id) {
+function onDeletePrompt(prompt) {
   promptStore
-    .deletePrompt(id)
+    .deletePrompt(prompt)
     .then(() => $q.notify({ type: 'positive', message: 'Prompt successfully deleted' }))
     .catch((error) => errorStore.throwError(error, 'Prompt deletion failed'))
 

--- a/src/components/Admin/PromptCard.vue
+++ b/src/components/Admin/PromptCard.vue
@@ -102,7 +102,7 @@
                   </div>
                 </div>
               </q-card>
-              <q-select data-test="select-author" disable label="Author" :options="authorOptions" v-model="prompt.author" />
+              <q-select data-test="select-author" disable label="Author" v-model="prompt.author" />
               <q-input
                 counter
                 data-test="input-title"
@@ -148,14 +148,14 @@
                       ['undo', 'redo']
                     ]"
                     v-model="prompt.description"
-                    @paste="onPaste($event)"
+                    @paste="handlePaste($event)"
                   />
                 </template>
               </q-field>
               <div class="row">
                 <div class="col-8">
                   <q-file
-                    accept=".jpg, image/*"
+                    accept=".jpg, .webp, image/*"
                     counter
                     data-test="file-image"
                     :hint="!prompt.image ? '*Image is required. Max size is 2MB.' : ''"
@@ -163,7 +163,7 @@
                     :max-total-size="2097152"
                     :required="!id"
                     use-chips
-                    v-model="imageModel"
+                    v-model="uploadedImage"
                     @rejected="onRejected()"
                     @update:model-value="uploadPhoto()"
                   >
@@ -328,16 +328,15 @@
 </template>
 
 <script setup>
-import { useQuasar, date as dateUtils, LocalStorage } from 'quasar'
+import { useQuasar, date as dateUtils } from 'quasar'
 import ShowcaseCard from 'src/components/Admin/ShowcaseCard.vue'
 import { useErrorStore, usePromptStore, useStorageStore, useUserStore } from 'src/stores'
-import { onMounted, reactive, ref, watchEffect, computed } from 'vue'
-import { uploadAndSetImage } from 'src/utils/imageConvertor'
+import { onMounted, reactive, ref, watchEffect, computed, watch, toRaw, nextTick } from 'vue'
 import CaptureCamera from '../shared/CameraCapture.vue'
 import FundDepositCard from './FundDepositCard.vue'
 import { customWeb3modal } from 'app/src/web3/walletConnect'
-import { collection, doc } from 'firebase/firestore'
-import { db } from 'src/firebase'
+import { onPaste } from 'src/utils/helpers'
+import { indexedDb } from 'src/utils/indexeddb'
 
 const emit = defineEmits(['hideDialog'])
 const props = defineProps([
@@ -364,30 +363,30 @@ const promptStore = usePromptStore()
 const storageStore = useStorageStore()
 const userStore = useUserStore()
 
-const authorOptions = reactive([])
-const prompt = reactive({
+const prompt = ref({
   description: '',
-  image: '',
-  showcase: { arts: [], artist: { info: '', photo: '' } },
+  image: null,
+  imageFile: null,
+  imagePath: null,
+  showcase: { arts: [], imageFiles: [], artist: { info: '', photo: '', imageFile: null } },
   categories: null,
   title: '',
   publicationDate: '',
   endDate: '',
   creationDate: new Date().toISOString().split('T')[0],
   paymentStatus: '',
-  rewardAmount: null
+  rewardAmount: null,
+  author: userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
 })
 
 const proceedDepositFundDialog = ref({})
 const step = ref(1)
-const imageModel = ref(null)
-const imagePreview = ref(null)
+const uploadedImage = ref(null)
 const editorRef = ref(null)
 const openCamera = ref(false)
-const promptFromLocalStorage = LocalStorage.getItem('prompt')
-const parsedPrompt = reactive(JSON.parse(promptFromLocalStorage) || undefined)
+const parsedPrompt = ref(null)
 
-function dateOptions(currentDate, creationDate = prompt.creationDate) {
+function dateOptions(currentDate, creationDate = prompt.value.creationDate) {
   const timestamp = dateUtils.startOfDate(creationDate, 'day').getTime()
   const today = new Date()
   const todayTimestamp = dateUtils.startOfDate(today, 'day').getTime()
@@ -397,7 +396,7 @@ function dateOptions(currentDate, creationDate = prompt.creationDate) {
 }
 
 function endDateOptions(currentDate) {
-  const publicationDate = dateUtils.addToDate(new Date(prompt.publicationDate), { days: 1 })
+  const publicationDate = dateUtils.addToDate(new Date(prompt.value.publicationDate), { days: 1 })
   const timestamp = dateUtils.startOfDate(publicationDate, 'day').getTime()
   const dateObj = dateUtils.extractDate(currentDate, 'YYYY/MM/DD')
   const limitObj = dateUtils.addToDate(timestamp, { months: 6 })
@@ -414,56 +413,37 @@ async function onProceedDepositFundDialog() {
   }
 }
 
-watchEffect(() => {
-  if (parsedPrompt && !props.id) {
-    const parsedCategories = parsedPrompt?.categories || []
-    prompt.author = { label: parsedPrompt?.author.label, value: parsedPrompt?.author.value }
-    prompt.categories = [...new Set([...parsedCategories])]
-    prompt.description = parsedPrompt?.description
-    prompt.showcase = parsedPrompt?.showcase
-    prompt.title = parsedPrompt?.title
-    prompt.id = parsedPrompt?.id
-
-    if (parsedPrompt?.image) {
-      imagePreview.value = parsedPrompt?.image
+onMounted(async () => {
+  await loadPromptFromDexie()
+  if (parsedPrompt.value && !props.id) {
+    prompt.value = {
+      ...prompt.value,
+      ...parsedPrompt.value,
+      author: userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
+    }
+    if (parsedPrompt.value.imageFile instanceof Blob) {
+      prompt.value.image = URL.createObjectURL(parsedPrompt.value.imageFile)
+      uploadedImage.value = parsedPrompt.value.imageFile
     }
   } else if (props.id) {
-    prompt.author = { label: props.author.displayName, value: props.author.uid }
-    prompt.categories = props.categories
-    prompt.creationDate = props.creationDate
-    prompt.publicationDate = props.publicationDate
-    prompt.endDate = props.endDate
-    prompt.description = props.description
-    prompt.id = props.id
-    prompt.image = props.image
-    prompt.showcase = props.showcase
-    prompt.title = props.title
-    prompt.paymentStatus = props.paymentStatus
-    prompt.rewardAmount = props.rewardAmount
-    if (props.image) {
-      imagePreview.value = props.image
-    }
-  } else {
-    const collectionRef = collection(db, 'prompts')
-    const docRef = doc(collectionRef)
-    prompt.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
-    prompt.description = ''
-    prompt.categories = null
-    prompt.id = docRef.id
+    prompt.value = { ...props, author: { label: props.author.displayName, value: props.author.uid } }
   }
 })
 
-onMounted(() => {
-  userStore.getAdminsAndEditors.forEach((user) => authorOptions.push({ label: user.displayName, value: user.uid }))
-
-  if (!props.id) {
-    prompt.publicationDate = ''
+async function loadPromptFromDexie() {
+  try {
+    const prompts = await indexedDb.prompt.toArray()
+    parsedPrompt.value = prompts[prompts.length - 1] || null
+  } catch (error) {
+    console.error('Failed to load entries from Dexie:', error)
+    parsedPrompt.value = null
   }
-})
+}
+
 const disablePublicationDate = computed(() => {
   if (!props.id) return false
-  const publicationDateData = new Date(props.publicationDate).getTime()
-  return parsedPrompt?.publicationDate ?? Date.now() >= publicationDateData
+  const publicationDateData = new Date(prompt.value.publicationDate).getTime()
+  return publicationDateData <= Date.now()
 })
 
 const disableEndDate = computed(() => {
@@ -472,83 +452,120 @@ const disableEndDate = computed(() => {
   return Date.now() >= endDateData
 })
 
-function uploadPhoto() {
-  prompt.image = ''
-  if (!imageModel.value) {
+async function uploadPhoto() {
+  if (!uploadedImage.value) {
+    if (prompt.value.image && !prompt.value.imagePath) {
+      URL.revokeObjectURL(prompt.value.image)
+    }
+    prompt.value.image = null
+    prompt.value.imageFile = null
     return
   }
-  const reader = new FileReader()
-  reader.readAsDataURL(imageModel.value)
-  reader.onload = () => (prompt.image = reader.result)
+
+  if (uploadedImage.value instanceof Blob) {
+    if (prompt.value.image && !prompt.value.imagePath) {
+      URL.revokeObjectURL(prompt.value.image)
+    }
+    prompt.value.imageFile = uploadedImage.value
+    prompt.value.image = URL.createObjectURL(prompt.value.imageFile)
+
+    // Update IndexedDB with only the image changes if record exists
+    if (parsedPrompt.value && parsedPrompt.value.id) {
+      await indexedDb.prompt.update(parsedPrompt.value.id, {
+        image: prompt.value.image,
+        imageFile: prompt.value.imageFile
+      })
+      parsedPrompt.value.image = prompt.value.image
+      parsedPrompt.value.imageFile = prompt.value.imageFile
+    }
+  }
 }
 
-function onPaste(evt) {
-  if (evt.target.nodeName === 'INPUT') return
-  let text, onPasteStripFormattingIEPaste
-  evt.preventDefault()
-  evt.stopPropagation()
-  if (evt.originalEvent && evt.originalEvent.clipboardData.getData) {
-    text = evt.originalEvent.clipboardData.getData('text/plain')
-    editorRef.value.runCmd('insertText', text)
-  } else if (evt.clipboardData && evt.clipboardData.getData) {
-    text = evt.clipboardData.getData('text/plain')
-    editorRef.value.runCmd('insertText', text)
-  } else if (window.clipboardData && window.clipboardData.getData) {
-    if (!onPasteStripFormattingIEPaste) {
-      onPasteStripFormattingIEPaste = true
-      editorRef.value.runCmd('ms-pasteTextOnly', text)
-    }
-    onPasteStripFormattingIEPaste = false
+function captureCamera(imageBlob) {
+  uploadedImage.value = imageBlob
+  prompt.value.imageFile = imageBlob
+  uploadPhoto()
+}
+
+function handlePaste(event) {
+  if (!editorRef.value) {
+    const unwatch = watch(
+      () => editorRef.value,
+      (newVal) => {
+        if (newVal) {
+          onPaste(event, editorRef)
+          unwatch()
+        }
+      }
+    )
+  } else {
+    onPaste(event, editorRef)
   }
 }
 
 async function onSubmit() {
-  prompt.slug = '/' + prompt.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')
-
-  if (!prompt.publicationDate) {
+  prompt.value.slug = '/' + prompt.value.title.toLowerCase().replace(/[^0-9a-z]+/g, '-')
+  if (!prompt.value.publicationDate) {
     $q.notify({ type: 'negative', message: 'Publication Date is required.' })
     return
   }
+
   if (!promptStore.getPrompts) {
-    const hasPrompt = await promptStore.hasPrompt(prompt.date, prompt.title, prompt.slug, !!props.id)
+    const hasPrompt = await promptStore.hasPrompt(prompt.value.date, prompt.value.title, prompt.value.slug, !!props.id)
     if (hasPrompt) {
       return
     }
   } else if (
-    promptStore.getPrompts?.find((p) => p.title.toLowerCase() === prompt.title.toLowerCase() && p.id !== prompt.id) ||
-    prompt.title.toLowerCase() === 'month'
+    promptStore.getPrompts?.find((p) => p.title.toLowerCase() === prompt.value.title.toLowerCase() && p.id !== prompt.value.id) ||
+    prompt.value.title.toLowerCase() === 'month'
   ) {
     $q.notify({ type: 'negative', message: 'Prompt with this title already exists. Please choose another title.' })
     return
   }
 
-  if (imageModel.value) {
-    const id = `${prompt.id}`
-    prompt.image = await uploadAndSetImage(imageModel.value, `images/prompt-${id}`)
-  }
-
   try {
     if (props.id) {
-      await promptStore.editPrompt(prompt)
+      await promptStore.editPrompt(prompt.value)
       $q.notify({ type: 'info', message: 'Prompt successfully edited' })
     } else {
+      // throw new Error('')
       await promptStore.addPrompt(prompt)
-      if (prompt.paymentStatus === 'Payment successful') {
+      if (prompt.value.paymentStatus === 'Payment successful') {
         $q.notify({ type: 'positive', message: 'Prompt successfully submitted.' })
       } else {
         $q.notify({ type: 'positive', message: 'Prompt successfully submitted. Please make sure to fund it.' })
       }
     }
-
-    if (parsedPrompt) {
-      LocalStorage.remove('prompt')
+    emit('hideDialog', prompt.value.slug)
+    indexedDb.prompt?.clear()
+  } catch (error) {
+    const promptToSave = {
+      author: toRaw(prompt.value.author),
+      description: toRaw(prompt.value.description),
+      showcase: toRaw(prompt.value.showcase),
+      title: toRaw(prompt.value.title),
+      categories: toRaw(prompt.value.categories),
+      publicationDate: toRaw(prompt.value.publicationDate),
+      endDate: toRaw(prompt.value.endDate),
+      creationDate: new Date().toISOString().split('T')[0],
+      imagePath: toRaw(prompt.value.imagePath),
+      paymentStatus: toRaw(prompt.value.paymentStatus),
+      rewardAmount: toRaw(prompt.value.rewardAmount)
     }
 
-    emit('hideDialog', prompt.slug)
-  } catch (error) {
-    await storageStore.deleteFile(`images/prompt-${prompt.id}`)
+    if (parsedPrompt.value && parsedPrompt.value.id) {
+      await indexedDb.prompt.update(parsedPrompt.value.id, promptToSave)
+    } else {
+      await indexedDb.prompt.add({
+        ...promptToSave,
+        imageFile: prompt.value.imageFile,
+        image: prompt.value.image
+      })
+    }
+
+    parsedPrompt.value = { ...prompt }
+    emit('hideDialog', prompt.value.slug)
     errorStore.throwError(error, props.id ? 'Prompt edit failed' : 'Prompt submission failed')
-    LocalStorage.set('prompt', JSON.stringify(prompt))
   }
 }
 
@@ -556,47 +573,69 @@ function onRejected() {
   $q.notify({ type: 'negative', message: 'File size is too big. Max file size is 2MB.' })
 }
 
-function captureCamera(imageBlob) {
-  imageModel.value = imageBlob
-  uploadPhoto()
-}
-
 function updatepaymentStatus(data) {
-  prompt.paymentStatus = data
+  prompt.value.paymentStatus = data
 }
 
 async function updatePaymentDetails(data) {
-  prompt.escrowId = data.escrowId
-  prompt.paymentStatus = data.paymentStatus
-  prompt.rewardAmount = data.rewardAmount
+  prompt.value.escrowId = data.escrowId
+  prompt.value.paymentStatus = data.paymentStatus
+  prompt.value.rewardAmount = data.rewardAmount
 
   await onSubmit()
 }
 
 const isNextStepDisabled = computed(() => {
   return (
-    !prompt.title ||
-    !prompt.description ||
-    !prompt.categories?.length ||
-    !prompt.image ||
+    !prompt.value.title ||
+    !prompt.value.description ||
+    !prompt.value.categories?.length ||
+    !prompt.value.image ||
     promptStore.isLoading ||
-    !prompt.publicationDate ||
-    !prompt.endDate
+    !prompt.value.publicationDate ||
+    !prompt.value.endDate
   )
 })
 
 function resetPrompt() {
-  LocalStorage.remove('prompt')
-  parsedPrompt.title = ''
-  parsedPrompt.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
-  parsedPrompt.categories = []
-  parsedPrompt.description = ''
-  parsedPrompt.image = null
-  prompt.showcase = { arts: [], artist: { info: '', photo: '' } }
-  imageModel.value = null
-  imagePreview.value = null
+  indexedDb.prompt?.clear()
+  const clearedPrompt = {
+    image: null,
+    imageFile: null,
+    imagePath: null,
+    showcase: { arts: [], artist: { info: '', photo: '' } },
+    categories: null,
+    title: '',
+    publicationDate: '',
+    endDate: '',
+    creationDate: new Date().toISOString().split('T')[0],
+    paymentStatus: '',
+    rewardAmount: '',
+    author: userStore.isAuthenticated
+      ? {
+          label: userStore.getUser.displayName,
+          value: userStore.getUser.uid
+        }
+      : null
+  }
 
-  $q.notify({ type: 'info', message: 'Prompt has been reset.' })
+  prompt.value = { ...clearedPrompt }
+  uploadedImage.value = null
+  parsedPrompt.value = null
+
+  nextTick(() => {
+    $q.notify({ type: 'info', message: 'Prompt has been reset.' })
+  })
+}
+
+function updateEndDate() {
+  if (prompt.value.publicationDate && prompt.value.endDate) {
+    const pubDate = new Date(prompt.value.publicationDate)
+    const endDate = new Date(prompt.value.endDate)
+    if (endDate <= pubDate) {
+      prompt.value.endDate = dateUtils.addToDate(pubDate, { days: 1 }).toISOString().split('T')[0]
+    }
+  }
 }
 </script>
 

--- a/src/components/Admin/PromptCard.vue
+++ b/src/components/Admin/PromptCard.vue
@@ -225,6 +225,7 @@
           <q-card-section class="q-mt-md q-pt-none" style="height: 65vh">
             <div class="q-my-lg">
               <ShowcaseCard
+                @update:artsToRemove="imagesToRemoveList"
                 collectionName="prompt"
                 :date="prompt.date"
                 v-model:arts="prompt.showcase.arts"
@@ -287,7 +288,7 @@
         </q-step>
 
         <template v-slot:navigation>
-          <q-stepper-navigation class="flex justify-end q-gutter-md">
+          <q-stepper-navigation class="flex justify-end q-gutter-md" style="padding: 16px">
             <template v-if="promptStore.isLoading">
               <q-skeleton type="rect" class="q-mr-md" style="height: 40px; width: 100px" />
               <q-skeleton type="rect" class="q-mr-md" style="height: 40px; width: 120px" />
@@ -423,6 +424,11 @@ async function onProceedDepositFundDialog() {
   }
 }
 
+const imagesToRemoveList = (e) => {
+  console.log(e)
+  prompt.value.artsToRemove = [...e]
+}
+
 onMounted(async () => {
   await loadPromptFromDexie()
   if (parsedPrompt.value && !props.id) {
@@ -459,10 +465,6 @@ watch(
   },
   { immediate: true }
 )
-
-onMounted(() => {
-  userStore.getAdminsAndEditors.forEach((user) => authorOptions.push({ label: user.displayName, value: user.uid }))
-})
 
 const disablePublicationDate = computed(() => {
   if (!props.id) return false
@@ -586,11 +588,11 @@ async function onSubmit() {
   }
 
   try {
+    emit('hideDialog', prompt.value.slug)
     if (props.id) {
       await promptStore.editPrompt(prompt.value)
       $q.notify({ type: 'info', message: 'Prompt successfully edited' })
     } else {
-      // throw new Error('')
       await promptStore.addPrompt(prompt)
       if (prompt.value.paymentStatus === 'Payment successful') {
         $q.notify({ type: 'positive', message: 'Prompt successfully submitted.' })
@@ -598,9 +600,9 @@ async function onSubmit() {
         $q.notify({ type: 'positive', message: 'Prompt successfully submitted. Please make sure to fund it.' })
       }
     }
-    emit('hideDialog', prompt.value.slug)
     indexedDb.prompt?.clear()
   } catch (error) {
+    emit('hideDialog', prompt.value.slug)
     const promptToSave = {
       author: toRaw(prompt.value.author),
       description: toRaw(prompt.value.description),
@@ -626,7 +628,6 @@ async function onSubmit() {
     }
 
     parsedPrompt.value = { ...prompt }
-    emit('hideDialog', prompt.value.slug)
     errorStore.throwError(error, props.id ? 'Prompt edit failed' : 'Prompt submission failed')
   }
 }
@@ -651,7 +652,6 @@ const isNextStepDisabled = computed(() => {
   return (
     !prompt.value.title ||
     !prompt.value.description ||
-    !prompt.value.categories?.length ||
     !prompt.value.image ||
     promptStore.isLoading ||
     !prompt.value.publicationDate ||

--- a/src/components/Admin/PromptCard.vue
+++ b/src/components/Admin/PromptCard.vue
@@ -288,6 +288,15 @@
               <q-btn v-if="step > 1" flat rounded @click="$refs.stepper.previous()" label="Back" :disable="promptStore.isLoading" />
 
               <q-btn
+                flat
+                rounded
+                label="Reset"
+                v-if="parsedPrompt?.title"
+                :disable="!parsedPrompt?.title"
+                data-test="button-reset"
+                @click="resetPrompt"
+              />
+              <q-btn
                 v-if="step === 3"
                 color="primary"
                 data-test="button-submit"
@@ -319,7 +328,7 @@
 </template>
 
 <script setup>
-import { useQuasar, date as dateUtils } from 'quasar'
+import { useQuasar, date as dateUtils, LocalStorage } from 'quasar'
 import ShowcaseCard from 'src/components/Admin/ShowcaseCard.vue'
 import { useErrorStore, usePromptStore, useStorageStore, useUserStore } from 'src/stores'
 import { onMounted, reactive, ref, watchEffect, computed } from 'vue'
@@ -360,6 +369,7 @@ const prompt = reactive({
   description: '',
   image: '',
   showcase: { arts: [], artist: { info: '', photo: '' } },
+  categories: null,
   title: '',
   publicationDate: '',
   endDate: '',
@@ -374,6 +384,8 @@ const imageModel = ref(null)
 const imagePreview = ref(null)
 const editorRef = ref(null)
 const openCamera = ref(false)
+const promptFromLocalStorage = LocalStorage.getItem('prompt')
+const parsedPrompt = reactive(JSON.parse(promptFromLocalStorage) || undefined)
 
 function dateOptions(currentDate, creationDate = prompt.creationDate) {
   const timestamp = dateUtils.startOfDate(creationDate, 'day').getTime()
@@ -403,7 +415,19 @@ async function onProceedDepositFundDialog() {
 }
 
 watchEffect(() => {
-  if (props.id) {
+  if (parsedPrompt && !props.id) {
+    const parsedCategories = parsedPrompt?.categories || []
+    prompt.author = { label: parsedPrompt?.author.label, value: parsedPrompt?.author.value }
+    prompt.categories = [...new Set([...parsedCategories])]
+    prompt.description = parsedPrompt?.description
+    prompt.showcase = parsedPrompt?.showcase
+    prompt.title = parsedPrompt?.title
+    prompt.id = parsedPrompt?.id
+
+    if (parsedPrompt?.image) {
+      imagePreview.value = parsedPrompt?.image
+    }
+  } else if (props.id) {
     prompt.author = { label: props.author.displayName, value: props.author.uid }
     prompt.categories = props.categories
     prompt.creationDate = props.creationDate
@@ -423,6 +447,7 @@ watchEffect(() => {
     const collectionRef = collection(db, 'prompts')
     const docRef = doc(collectionRef)
     prompt.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
+    prompt.description = ''
     prompt.categories = null
     prompt.id = docRef.id
   }
@@ -438,7 +463,7 @@ onMounted(() => {
 const disablePublicationDate = computed(() => {
   if (!props.id) return false
   const publicationDateData = new Date(props.publicationDate).getTime()
-  return Date.now() >= publicationDateData
+  return parsedPrompt?.publicationDate ?? Date.now() >= publicationDateData
 })
 
 const disableEndDate = computed(() => {
@@ -515,9 +540,15 @@ async function onSubmit() {
       }
     }
 
+    if (parsedPrompt) {
+      LocalStorage.remove('prompt')
+    }
+
     emit('hideDialog', prompt.slug)
   } catch (error) {
+    await storageStore.deleteFile(`images/prompt-${prompt.id}`)
     errorStore.throwError(error, props.id ? 'Prompt edit failed' : 'Prompt submission failed')
+    LocalStorage.set('prompt', JSON.stringify(prompt))
   }
 }
 
@@ -539,7 +570,7 @@ async function updatePaymentDetails(data) {
   prompt.paymentStatus = data.paymentStatus
   prompt.rewardAmount = data.rewardAmount
 
-  onSubmit()
+  await onSubmit()
 }
 
 const isNextStepDisabled = computed(() => {
@@ -553,6 +584,20 @@ const isNextStepDisabled = computed(() => {
     !prompt.endDate
   )
 })
+
+function resetPrompt() {
+  LocalStorage.remove('prompt')
+  parsedPrompt.title = ''
+  parsedPrompt.author = userStore.isAuthenticated ? { label: userStore.getUser.displayName, value: userStore.getUser.uid } : null
+  parsedPrompt.categories = []
+  parsedPrompt.description = ''
+  parsedPrompt.image = null
+  prompt.showcase = { arts: [], artist: { info: '', photo: '' } }
+  imageModel.value = null
+  imagePreview.value = null
+
+  $q.notify({ type: 'info', message: 'Prompt has been reset.' })
+}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/Admin/ShowcaseCard.vue
+++ b/src/components/Admin/ShowcaseCard.vue
@@ -56,11 +56,11 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onBeforeMount } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useQuasar } from 'quasar'
 
 const props = defineProps(['arts', 'artist', 'collectionName', 'date', 'entryTitle'])
-const emit = defineEmits(['update:arts', 'update:artist'])
+const emit = defineEmits(['update:arts', 'update:artist', 'update:artsToRemove'])
 const $q = useQuasar()
 const artsFileRef = ref(null)
 const artistFileRef = ref(null)
@@ -69,6 +69,7 @@ const modelArtistInfo = ref(props.artist?.info || '')
 const modelArtistPhoto = ref(props.artist?.preview || '')
 const modelFileArt = ref(null)
 const modelFileArtist = ref(null)
+const artsToRemove = ref([])
 
 // File size validation
 function checkFileSize(files) {
@@ -145,6 +146,12 @@ function removeArt(index) {
   if (art.preview?.startsWith('blob:')) {
     URL.revokeObjectURL(art.preview)
   }
+
+  if (art?.preview?.startsWith('https://') || (typeof art === 'string' && art.startsWith('https://'))) {
+    artsToRemove.value.push(art.preview ?? art)
+    emit('update:artsToRemove', [...artsToRemove.value])
+  }
+
   modelArts.value.splice(index, 1)
   emit('update:arts', modelArts.value)
 }

--- a/src/components/Admin/ShowcaseCard.vue
+++ b/src/components/Admin/ShowcaseCard.vue
@@ -14,7 +14,7 @@
       class="hidden"
       ref="artistFileRef"
       v-model="modelFileArtist"
-      @update:model-value="addArtistPhoto"
+      @update:model-value="uploadArtistPhoto"
       :filter="checkFileSize"
       @rejected="onRejected"
       accept="image/*"
@@ -22,9 +22,7 @@
     />
     <q-btn flat icon="add_circle_outline" label="Upload Artist Photo" rounded @click="onUploadArtist" />
     <div v-if="modelArtistPhoto" class="items-center no-wrap q-my-md q-pa-md rounded-borders col shadow-1">
-      <q-spinner v-if="storageStore.isLoading && !modelArtistPhoto" class="q-mx-auto" color="primary" size="3em" style="width: 50%" />
       <q-img
-        v-else
         class="artist-img q-mr-md rounded-borders"
         fit="contain"
         :src="modelArtistPhoto"
@@ -37,7 +35,7 @@
       class="hidden"
       ref="artsFileRef"
       v-model="modelFileArt"
-      @update:model-value="addArts"
+      @update:model-value="uploadArts"
       :filter="checkFileSize"
       @rejected="onRejected"
       accept="image/*"
@@ -49,104 +47,136 @@
       <q-tooltip>Max 10 Images</q-tooltip>
     </q-btn>
     <div v-if="modelArts.length" class="items-center q-my-md q-pa-md rounded-borders row shadow-1">
-      <q-spinner v-if="storageStore.isLoading && !modelArts.length" class="q-mx-auto" color="primary" size="3em" />
       <div v-for="(art, index) in modelArts" class="art-img q-ma-xs relative-position" :key="index">
-        <q-img class="rounded-borders" fit="cover" :ratio="1" :src="art" style="width: 10rem" data-test="arts-images" />
-        <q-btn class="trash-icon" color="negative" icon="delete" round size="sm" @click="removeArt(art)" data-test="remove-art-btn" />
+        <q-img class="rounded-borders" fit="cover" :ratio="1" :src="art.preview ?? art" style="width: 10rem" data-test="arts-images" />
+        <q-btn class="trash-icon" color="negative" icon="delete" round size="sm" @click="removeArt(index)" data-test="remove-art-btn" />
       </div>
     </div>
   </section>
 </template>
 
 <script setup>
-import { useErrorStore, useStorageStore } from 'src/stores'
-import { ref } from 'vue'
+import { ref, onMounted, onBeforeMount } from 'vue'
 import { useQuasar } from 'quasar'
-import { uploadAndSetImage } from 'src/utils/imageConvertor'
-import { uid } from 'quasar'
 
 const props = defineProps(['arts', 'artist', 'collectionName', 'date', 'entryTitle'])
-const emit = defineEmits(['update:arts', 'update:artist', 'updateRecentUploads', 'updateRecentArtistImage'])
-
-const errorStore = useErrorStore()
-const storageStore = useStorageStore()
-
+const emit = defineEmits(['update:arts', 'update:artist'])
+const $q = useQuasar()
 const artsFileRef = ref(null)
 const artistFileRef = ref(null)
-const modelArts = ref(props.arts || [])
-const modelArtistInfo = ref(props.artist.info)
-const modelArtistPhoto = ref(props.artist.photo)
+const modelArts = ref([])
+const modelArtistInfo = ref(props.artist?.info || '')
+const modelArtistPhoto = ref(props.artist?.preview || '')
 const modelFileArt = ref(null)
 const modelFileArtist = ref(null)
-const $q = useQuasar()
 
-function onUploadArts() {
-  artsFileRef.value.pickFiles()
-}
-
-function onUploadArtist() {
-  artistFileRef.value.pickFiles()
-}
-
+// File size validation
 function checkFileSize(files) {
-  return files.filter((file) => file.size > 2048)
+  return files.filter((file) => file.size <= 2097152)
 }
 
-function onRejected(rejectedEntries) {
+// Notify on rejected files
+function onRejected() {
   $q.notify({
     type: 'negative',
-    message: `${rejectedEntries.length} file(s) did not pass validation constraints`
+    message: `File size is too big. Max file size is 2MB.`
   })
 }
 
-async function addArts(files) {
-  const maxImages = 10
-  const remainingImages = maxImages - modelArts.value.length
+// Trigger artist photo upload
+function onUploadArtist() {
+  artistFileRef.value?.pickFiles()
+}
 
-  if (remainingImages <= 0) {
-    $q.notify({ type: 'negative', message: `You can only upload ${maxImages} images` })
-    await errorStore.throwError(`You can only upload ${maxImages} images`)
+// Trigger arts upload
+function onUploadArts() {
+  artsFileRef.value?.pickFiles()
+}
+
+// Handle artist photo upload
+async function uploadArtistPhoto(file) {
+  if (!file) {
+    if (modelArtistPhoto.value && modelArtistPhoto.value.startsWith('blob:')) {
+      URL.revokeObjectURL(modelArtistPhoto.value)
+    }
+    modelArtistPhoto.value = ''
+    modelFileArtist.value = null
+    emit('update:artist', { info: modelArtistInfo.value, photo: '', file: null })
     return
   }
 
-  const filesToUpload = files.slice(0, remainingImages)
-
-  for (const index in filesToUpload) {
-    const uploaded = await uploadAndSetImage(filesToUpload[index], `images/${props.collectionName}-${props.date}-${uid()}`)
-    modelArts.value.push(uploaded)
-    emit('updateRecentUploads', uploaded)
-  }
-
-  emit('update:arts', modelArts.value)
-
-  if (filesToUpload.length < files.length) {
-    $q.notify({
-      type: 'negative',
-      message: `${filesToUpload.length} file(s) were uploaded. You can upload maximum 10 images`
+  if (file instanceof Blob) {
+    if (modelArtistPhoto.value && modelArtistPhoto.value.startsWith('blob:')) {
+      URL.revokeObjectURL(modelArtistPhoto.value)
+    }
+    modelFileArtist.value = file
+    modelArtistPhoto.value = URL.createObjectURL(file)
+    emit('update:artist', {
+      info: modelArtistInfo.value,
+      photo: modelArtistPhoto.value,
+      file: modelFileArtist.value
     })
   }
 }
 
-function removeArt(file) {
-  const index = modelArts.value.indexOf(file)
-  const imgId = file.match(/entry-[^?\/]+/)
-  storageStore
-    .deleteFile(`images/${imgId}`)
-    .then(() => modelArts.value.splice(index, 1))
-    .catch((error) => errorStore.throwError(error))
+// Handle arts upload
+async function uploadArts(files) {
+  const maxImages = 10
+  const remainingImages = maxImages - modelArts.value.length
+
+  if (!files || files.length === 0) return
+  if (remainingImages <= 0) {
+    $q.notify({ type: 'negative', message: `You can only upload ${maxImages} images` })
+    return
+  }
+  const filesToPreview = Array.from(files).slice(0, remainingImages)
+
+  filesToPreview.forEach((file) => {
+    if (file instanceof Blob) {
+      modelArts.value.push({ file: file, preview: URL.createObjectURL(file) })
+    }
+  })
   emit('update:arts', modelArts.value)
 }
 
-async function addArtistPhoto(files) {
-  modelArtistPhoto.value = ''
-  modelArtistPhoto.value = await uploadAndSetImage(files, `images/${props.collectionName}-${props.date}-artist`)
-  emit('update:artist', { ...props.artist, photo: modelArtistPhoto.value })
-  emit('updateRecentArtistImage', modelArtistPhoto.value)
+// Remove an art item
+function removeArt(index) {
+  const art = modelArts.value[index]
+  if (art.preview?.startsWith('blob:')) {
+    URL.revokeObjectURL(art.preview)
+  }
+  modelArts.value.splice(index, 1)
+  emit('update:arts', modelArts.value)
 }
 
+// Update artist info
 function addArtistInfo() {
-  emit('update:artist', { ...props.artist, info: modelArtistInfo.value })
+  emit('update:artist', {
+    info: modelArtistInfo.value,
+    photo: modelArtistPhoto.value,
+    file: modelFileArtist.value
+  })
 }
+
+onMounted(async () => {
+  if (props) {
+    if (props.artist && props.artist.file instanceof Blob) {
+      modelArtistPhoto.value = URL.createObjectURL(props.artist.file)
+    }
+
+    if (props.arts) {
+      props.arts.forEach((art) => {
+        if (art && art.file instanceof Blob) {
+          art = { file: art.file, preview: URL.createObjectURL(art.file) }
+          modelArts.value.push(art)
+          return art
+        } else {
+          modelArts.value.push(art)
+        }
+      })
+    }
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Admin/TableEntry.vue
+++ b/src/components/Admin/TableEntry.vue
@@ -148,13 +148,7 @@
       </q-card-section>
       <q-card-actions align="right">
         <q-btn color="primary" flat label="Cancel" v-close-popup />
-        <q-btn
-          color="negative"
-          data-test="confirm-delete-entry"
-          flat
-          label="Delete"
-          @click="onDeleteEntry(deleteDialog.entry.id, deleteDialog.entry.prompt.id, deleteDialog.entry.showcase.arts)"
-        />
+        <q-btn color="negative" data-test="confirm-delete-entry" flat label="Delete" @click="onDeleteEntry(deleteDialog.entry)" />
       </q-card-actions>
     </q-card>
   </q-dialog>
@@ -375,14 +369,14 @@ function forwardHandleUpdateEntry(payload) {
   emit('update-entry', payload)
 }
 
-function onDeleteEntry(entryId, promptId, arts) {
+function onDeleteEntry(entry) {
   entryStore
-    .deleteEntry(entryId, arts)
+    .deleteEntry(entry)
     .then(() => {
       if (!userStore.isEditorOrAbove) {
         entryStore.fetchUserRelatedEntries(userStore.getUserId)
       } else if (userStore.isEditorOrAbove) {
-        emit('delete-entry', entryId, promptId)
+        emit('delete-entry', entry.id, entry.prompt.id)
       }
     })
     .then(() => $q.notify({ type: 'positive', message: 'Entry deleted' }))

--- a/src/components/Admin/TableEntry.vue
+++ b/src/components/Admin/TableEntry.vue
@@ -130,7 +130,7 @@
     </template>
   </q-table>
 
-  <q-dialog full-width position="bottom" v-model="entry.dialog" no-backdrop-dismiss no-refocus no-esc-dismiss>
+  <q-dialog full-width position="bottom" v-model="entry.dialog">
     <EntryCard v-bind="entry" @hideDialog="entry = {}" @forward-update-entry="forwardHandleUpdateEntry" />
   </q-dialog>
 

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -135,7 +135,7 @@
               mask="#.##"
               fill-mask="0"
               reverse-fill-mask
-              :rules="[() => (usdAmount < 0.01 ? 'Minimum allowed budget is 3 USD' : true)]"
+              :rules="[() => (usdAmount < 3 ? 'Minimum allowed budget is 3 USD' : true)]"
               @update:model-value="convertToMatic()"
             />
             <q-input

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -135,7 +135,7 @@
               mask="#.##"
               fill-mask="0"
               reverse-fill-mask
-              :rules="[() => (usdAmount < 3 ? 'Minimum allowed budget is 3 USD' : true)]"
+              :rules="[() => (usdAmount < 0.01 ? 'Minimum allowed budget is 3 USD' : true)]"
               @update:model-value="convertToMatic()"
             />
             <q-input
@@ -150,6 +150,7 @@
         </q-step>
         <template v-slot:navigation>
           <q-stepper-navigation class="flex justify-end q-gutter-md">
+            <q-btn flat rounded label="Reset" @click="resetAd" v-if="parsedAd?.title" data-test="reset-button" />
             <q-btn flat rounded label="Cancel" v-close-popup />
             <q-btn
               rounded
@@ -175,7 +176,7 @@
 <script setup>
 import { db } from 'src/firebase'
 import { collection, doc } from 'firebase/firestore'
-import { useQuasar } from 'quasar'
+import { LocalStorage, useQuasar } from 'quasar'
 import { useAdvertiseStore, useErrorStore, useStorageStore, useUserStore } from 'src/stores'
 import { calculateEndDate, currentYearMonth, getCurrentDate } from 'src/utils/date'
 import { onMounted, reactive, ref, watchEffect } from 'vue'
@@ -215,6 +216,8 @@ const usdAmount = ref(0)
 const maticRate = ref(0)
 const isEditing = ref(false)
 const editorRef = ref(null)
+const adFromLocalStorage = LocalStorage.getItem('ad')
+const parsedAd = reactive(JSON.parse(adFromLocalStorage) || undefined)
 
 function openDatePicker() {
   datePickerVisible.value = true
@@ -242,7 +245,20 @@ const advertise = reactive({
 const step = ref(1)
 
 watchEffect(() => {
-  if (props.id) {
+  if (parsedAd && !props.id) {
+    advertise.author = parsedAd.author
+    advertise.categories = parsedAd.categories
+    advertise.date = parsedAd.date
+    advertise.content = parsedAd.content
+    advertise.id = parsedAd.id
+    advertise.title = parsedAd.title
+    advertise.productLink = parsedAd.productLink
+    advertise.publishDate = parsedAd.publishDate
+    advertise.type = parsedAd.type
+    advertise.duration = parsedAd.duration
+    advertise.status = parsedAd.status
+    advertise.contentURL = parsedAd.contentURL ?? ''
+  } else if (props.id) {
     advertise.author = props.author
     advertise.categories = props.categories
     advertise.date = props.date
@@ -359,6 +375,7 @@ async function onSubmit() {
         .finally(() => $q.loading.hide())
     } else {
       //call contract create function
+      // throw new Error('')
       const result = await createAdCampaign({ budgetInMatic: advertise.budget })
       if (result.status.includes('success')) {
         advertise.campaignCode = result.events[0].args.campaignCode
@@ -378,14 +395,38 @@ async function onSubmit() {
         $q.notify({ message: result?.error?.message, type: 'negative' })
         $q.loading.hide()
       }
+
+      if (parsedAd) {
+        LocalStorage.remove('ad')
+      }
     }
     emit('hideDialog')
   } catch (error) {
     $q.notify({ message: 'Advertise submission failed', type: 'negative' })
     errorStore.throwError(error, 'Advertise submission failed')
+    LocalStorage.set('ad', JSON.stringify(advertise))
     emit('hideDialog')
     $q.loading.hide()
   }
   emit('hideDialog')
+}
+
+function resetAd() {
+  LocalStorage.remove('ad')
+  parsedAd.title = ''
+  parsedAd.author = parsedAd.categories = null
+  parsedAd.date = null
+  parsedAd.content = ''
+  parsedAd.id = null
+  parsedAd.title = ''
+  parsedAd.productLink = ''
+  parsedAd.publishDate = null
+  parsedAd.type = null
+  parsedAd.duration = ''
+  parsedAd.status = ''
+  parsedAd.contentURL = ''
+  ;(advertise.budget = props.budget), (advertise.type = props.type)
+
+  $q.notify({ type: 'info', message: 'Prompt has been reset.' })
 }
 </script>

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -375,7 +375,6 @@ async function onSubmit() {
         .finally(() => $q.loading.hide())
     } else {
       //call contract create function
-      // throw new Error('')
       const result = await createAdCampaign({ budgetInMatic: advertise.budget })
       if (result.status.includes('success')) {
         advertise.campaignCode = result.events[0].args.campaignCode
@@ -393,6 +392,7 @@ async function onSubmit() {
           .finally(() => $q.loading.hide())
       } else {
         $q.notify({ message: result?.error?.message, type: 'negative' })
+        LocalStorage.set('ad', JSON.stringify(advertise))
         $q.loading.hide()
       }
 

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -257,7 +257,6 @@ watchEffect(() => {
     advertise.type = parsedAd.type
     advertise.duration = parsedAd.duration
     advertise.status = parsedAd.status
-    advertise.contentURL = parsedAd.contentURL ?? ''
   } else if (props.id) {
     advertise.author = props.author
     advertise.categories = props.categories

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -390,14 +390,14 @@ async function onSubmit() {
             errorStore.throwError(error, 'Advertise submission failed')
           })
           .finally(() => $q.loading.hide())
+
+        if (parsedAd) {
+          LocalStorage.remove('ad')
+        }
       } else {
         $q.notify({ message: result?.error?.message, type: 'negative' })
         LocalStorage.set('ad', JSON.stringify(advertise))
         $q.loading.hide()
-      }
-
-      if (parsedAd) {
-        LocalStorage.remove('ad')
       }
     }
     emit('hideDialog')

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -258,7 +258,7 @@ onMounted(async () => {
     advertise.value = {
       ...advertise.value,
       ...parsedAd.value,
-      author: userStore.isAuthenticated ? { id: userStore.getUser.uid } : null,
+      author: userStore.isAuthenticated ? { uid: userStore.getUser.uid } : null,
       id: docRef.id
     }
 
@@ -281,6 +281,7 @@ onMounted(async () => {
     advertise.value.duration = props.duration
     advertise.value.status = props.status
     advertise.value.contentURL = props.contentURL ?? ''
+    advertise.value.campaignCode = props.campaignCode ?? ''
   } else {
     advertise.value = {
       ...advertise.value,
@@ -428,13 +429,6 @@ async function onSubmit() {
     $q.loading.show()
     advertise.value.endDate = calculateEndDate(advertise.value.publishDate, advertise.value.duration)
     if (advertise.value.type === 'Text') advertise.value.contentURL = ''
-    // if (Object.keys(contentModel.value).length && advertise.value.type === 'Banner') {
-    //   await storageStore
-    //     .uploadFile(contentModel.value, `advertise/content-${advertise.value.id}`)
-    //     .then((url) => (advertise.value.contentURL = url))
-    //     .catch((error) => errorStore.throwError(error))
-    // }
-
     if (props.id) {
       if (props.type === 'Banner' && advertise.value.type === 'Text') {
         const imagePath = `advertise/content-${advertise.value.id}`
@@ -452,7 +446,6 @@ async function onSubmit() {
       const result = await createAdCampaign({ budgetInMatic: advertise.value.budget })
       if (result.status.includes('success')) {
         advertise.value.campaignCode = result.events[0].args.campaignCode
-        // throw new Error('')
         await advertiseStore
           .addAdvertise(advertise.value)
           .then(() => {

--- a/src/components/Advertiser/AdvertiseCard.vue
+++ b/src/components/Advertiser/AdvertiseCard.vue
@@ -22,7 +22,7 @@
             </div>
             <q-file
               v-if="advertise.type === 'Banner'"
-              v-model="contentModel"
+              v-model="uploadedImage"
               counter
               class="q-mb-lg"
               data-test="file-image"
@@ -41,11 +41,11 @@
             </q-file>
             <div v-if="advertise.type === 'Banner'" class="text-center">
               <q-img
-                v-if="advertise.contentURL"
+                v-if="advertise.image"
                 class="q-mt-md"
                 fit="contain"
                 style="max-height: 40vh; max-width: 80vw"
-                :src="advertise.contentURL"
+                :src="advertise.image"
               />
             </div>
             <q-field
@@ -132,18 +132,18 @@
               :rules="[(duration) => duration > 0 || 'Enter a positive number']"
             />
             <q-input
-              v-if="!isEditing"
+              v-if="!props.id"
               v-model="usdAmount"
               label="Price in USD"
               :hint="!usdAmount ? '*Minimum Price is required' : ''"
               mask="#.##"
               fill-mask="0"
               reverse-fill-mask
-              :rules="[() => (usdAmount < 3 ? 'Minimum allowed budget is 3 USD' : true)]"
+              :rules="[() => (usdAmount < 0.1 ? 'Minimum allowed budget is 3 USD' : true)]"
               @update:model-value="convertToMatic()"
             />
             <q-input
-              v-if="!isEditing"
+              v-if="!props.id"
               v-model="advertise.budget"
               readonly
               label="Budget In POL"
@@ -166,7 +166,7 @@
                 !advertise.content ||
                 !advertise.duration ||
                 !advertise.publishDate ||
-                (advertise.type === 'Banner' && (fileError || (contentModel.length <= 0 && advertise.contentURL.length <= 0)))
+                (advertise.type === 'Banner' && (fileError || (uploadedImage?.length <= 0 && advertise.contentURL.length <= 0)))
               "
               :label="id ? 'Save Edits' : 'Submit '"
             />
@@ -183,15 +183,15 @@ import { collection, doc } from 'firebase/firestore'
 import { LocalStorage, useQuasar } from 'quasar'
 import { useAdvertiseStore, useErrorStore, useStorageStore, useUserStore } from 'src/stores'
 import { calculateEndDate, currentYearMonth, getCurrentDate } from 'src/utils/date'
-import { onMounted, reactive, ref, watchEffect, watch } from 'vue'
+import { onMounted, ref, watch, toRaw, nextTick } from 'vue'
 import { contractCreateAdCampaign } from 'app/src/web3/adCampaignManager'
 import { customWeb3modal } from 'app/src/web3/walletConnect'
 import { fetchMaticRate } from 'app/src/web3/transfers.js'
+import { indexedDb } from 'src/utils/indexeddb'
 
 const emit = defineEmits(['hideDialog'])
 const props = defineProps([
   'author',
-  'categories',
   'date',
   'content',
   'id',
@@ -201,6 +201,7 @@ const props = defineProps([
   'type',
   'content',
   'duration',
+  'image',
   'status',
   'contentURL',
   'budget',
@@ -212,21 +213,34 @@ const errorStore = useErrorStore()
 const advertiseStore = useAdvertiseStore()
 const storageStore = useStorageStore()
 const userStore = useUserStore()
-const contentModel = ref([])
 const datePickerVisible = ref(false)
 const fileErrorMessage = ref('')
 const fileError = ref(false)
 const usdAmount = ref(0)
 const maticRate = ref(0)
-const isEditing = ref(false)
 const editorRef = ref(null)
+const uploadedImage = ref(null)
 const lastDescriptionNotificationTime = ref(0)
-const adFromLocalStorage = LocalStorage.getItem('ad')
-const parsedAd = reactive(JSON.parse(adFromLocalStorage) || undefined)
+const parsedAd = ref(null)
+const advertise = ref({
+  content: '',
+  title: '',
+  productLink: '',
+  contentURL: '',
+  campaignCode: '',
+  type: '',
+  image: '',
+  imageFile: '',
+  imagePath: '',
+  author: ''
+})
 
+const collectionRef = collection(db, 'advertises')
+const docRef = doc(collectionRef)
 function openDatePicker() {
   datePickerVisible.value = true
 }
+
 onMounted(async () => {
   if (!customWeb3modal.getAddress()) {
     customWeb3modal.open()
@@ -238,74 +252,85 @@ onMounted(async () => {
   } else {
     $q.notify({ type: 'negative', message: 'Failed to fetch Pol rate' })
   }
-})
 
-const advertise = reactive({
-  content: '',
-  title: '',
-  productLink: '',
-  contentURL: '',
-  campaignCode: ''
-})
-const step = ref(1)
+  await loadPromptFromDexie()
+  if (parsedAd.value && !props.id) {
+    usdAmount.value = parsedAd.value.usdAmount
+    advertise.value = {
+      ...advertise.value,
+      ...parsedAd.value,
+      author: userStore.isAuthenticated ? { id: userStore.getUser.uid } : null,
+      id: docRef.id
+    }
 
-watchEffect(() => {
-  if (parsedAd && !props.id) {
-    advertise.author = parsedAd.author
-    advertise.categories = parsedAd.categories
-    advertise.date = parsedAd.date
-    advertise.content = parsedAd.content
-    advertise.id = parsedAd.id
-    advertise.title = parsedAd.title
-    advertise.productLink = parsedAd.productLink
-    advertise.publishDate = parsedAd.publishDate
-    advertise.type = parsedAd.type
-    advertise.duration = parsedAd.duration
-    advertise.status = parsedAd.status
+    if (parsedAd.value.imageFile instanceof Blob) {
+      advertise.value.image = URL.createObjectURL(parsedAd.value.imageFile)
+      uploadedImage.value = parsedAd.value.imageFile
+    }
   } else if (props.id) {
-    advertise.author = props.author
-    advertise.categories = props.categories
-    advertise.date = props.date
-    advertise.content = props.content
-    advertise.id = props.id
-    advertise.title = props.title
-    advertise.productLink = props.productLink
-    advertise.publishDate = props.publishDate
-    advertise.type = props.type
-    advertise.duration = props.duration
-    advertise.status = props.status
-    advertise.contentURL = props.contentURL ?? ''
-    ;(advertise.budget = props.budget), (advertise.type = props.type)
-    isEditing.value = true
+    advertise.value.author = props.author
+    advertise.value.categories = props.categories
+    advertise.value.date = props.date
+    advertise.value.content = props.content
+    advertise.value.id = props.id
+    advertise.value.title = props.title
+    advertise.value.image = props.image || ''
+    advertise.value.productLink = props.productLink
+    advertise.value.publishDate = props.publishDate
+    advertise.value.type = props.type
+    advertise.value.budget = props.budget
+    advertise.value.duration = props.duration
+    advertise.value.status = props.status
+    advertise.value.contentURL = props.contentURL ?? ''
   } else {
-    const collectionRef = collection(db, 'advertises')
-    const docRef = doc(collectionRef)
-
-    advertise.author = userStore.isAuthenticated ? { userName: userStore.getUser.displayName, uid: userStore.getUser.uid } : null
-    advertise.categories = []
-    advertise.type = 'Banner'
-    advertise.date = currentYearMonth()
-    advertise.status = 'Inactive'
-    advertise.cost = 0
-    advertise.id = docRef.id
-    isEditing.value = false
+    advertise.value = {
+      ...advertise.value,
+      author: userStore.isAuthenticated ? { uid: userStore.getUser.uid } : null,
+      id: docRef.id
+    }
   }
 })
 
-function uploadPhoto() {
-  advertise.contentURL = ''
-  const reader = new FileReader()
-  reader.readAsDataURL(contentModel.value)
-  reader.onload = () => (advertise.contentURL = reader.result)
-  reader.onloadend = function (e) {
-    const image = new Image()
-    image.src = e.target.result
-    image.onload = function () {
-      if (image.width < 500 || image.height < 252) {
-        $q.notify({ type: 'negative', message: `Please select an image with minimum 500px width & 252px height for better view` })
-        fileErrorMessage.value = 'Select an image with minimum 500px width & 252px height '
-        fileError.value = true
-      } else fileError.value = false
+async function loadPromptFromDexie() {
+  try {
+    const ads = await indexedDb.ad.toArray()
+    parsedAd.value = ads[ads.length - 1] || null
+  } catch (error) {
+    console.error('Failed to load entries from Dexie:', error)
+    parsedAd.value = null
+  }
+}
+
+const step = ref(1)
+
+async function uploadPhoto() {
+  if (!uploadedImage.value) {
+    if (advertise.value.image && !advertise.value.imagePath) {
+      URL.revokeObjectURL(advertise.value.image)
+    }
+    advertise.value.image = null
+    advertise.value.imageFile = null
+    return
+  }
+
+  if (uploadedImage.value instanceof Blob) {
+    if (advertise.value.image && !advertise.value.imagePath) {
+      URL.revokeObjectURL(advertise.value.image)
+    }
+    advertise.value.imageFile = uploadedImage.value
+    advertise.value.image = URL.createObjectURL(advertise.value.imageFile)
+    if (parsedAd.value) {
+      parsedAd.value.image = URL.createObjectURL(advertise.value.imageFile)
+    }
+    // UPDATE INDEXEDDB IMAGE IF IT EXISTS
+    if (parsedAd.value && parsedAd.value.id) {
+      await indexedDb.ad.update(parsedAd.value.id, {
+        image: advertise.value.image,
+        imageFile: advertise.value.imageFile
+      })
+
+      parsedAd.value.image = advertise.value.image
+      parsedAd.value.imageFile = advertise.value.imageFile
     }
   }
 }
@@ -326,7 +351,7 @@ async function createAdCampaign(payload) {
 }
 function convertToMatic() {
   if (maticRate.value && usdAmount.value && maticRate.value) {
-    advertise.budget = (usdAmount.value / maticRate.value).toFixed(6)
+    advertise.value.budget = (usdAmount.value / maticRate.value).toFixed(6)
   }
 }
 
@@ -348,7 +373,7 @@ function onKeyDown(event) {
     return
   }
 
-  if (advertise.content.length >= 6000) {
+  if (advertise.value.content.length >= 6000) {
     if (!['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(event.key)) {
       event.preventDefault()
       showDescriptionNotification('Max 6000 characters reached')
@@ -362,7 +387,7 @@ function onPaste(evt) {
   evt.preventDefault()
   evt.stopPropagation()
 
-  const currentLength = advertise.content.length
+  const currentLength = advertise.value.content.length
 
   if (evt.originalEvent && evt.originalEvent.clipboardData.getData) {
     text = evt.originalEvent.clipboardData.getData('text/plain')
@@ -388,10 +413,10 @@ function onPaste(evt) {
 }
 
 watch(
-  () => advertise.content,
+  () => advertise.value.content,
   (newContent) => {
     if (newContent && newContent.length > 6000) {
-      advertise.content = newContent.substring(0, 6000)
+      advertise.value.content = newContent.substring(0, 6000)
     }
   },
   { immediate: true }
@@ -399,83 +424,119 @@ watch(
 
 async function onSubmit() {
   try {
-    if (!advertise.budget) advertise.budget = 0
+    if (!advertise.value.budget) advertise.value.budget = 0
 
     $q.loading.show()
-    advertise.endDate = calculateEndDate(advertise.publishDate, advertise.duration)
-    if (advertise.type === 'Text') advertise.contentURL = ''
-    else if (Object.keys(contentModel.value).length && advertise.type === 'Banner') {
-      await storageStore
-        .uploadFile(contentModel.value, `advertise/content-${advertise.id}`)
-        .then((url) => (advertise.contentURL = url))
-        .catch((error) => errorStore.throwError(error))
-    }
+    advertise.value.endDate = calculateEndDate(advertise.value.publishDate, advertise.value.duration)
+    if (advertise.value.type === 'Text') advertise.value.contentURL = ''
+    // if (Object.keys(contentModel.value).length && advertise.value.type === 'Banner') {
+    //   await storageStore
+    //     .uploadFile(contentModel.value, `advertise/content-${advertise.value.id}`)
+    //     .then((url) => (advertise.value.contentURL = url))
+    //     .catch((error) => errorStore.throwError(error))
+    // }
 
     if (props.id) {
-      if (props.type === 'Banner' && advertise.type === 'Text') {
-        const imagePath = `advertise/content-${advertise.id}`
+      if (props.type === 'Banner' && advertise.value.type === 'Text') {
+        const imagePath = `advertise/content-${advertise.value.id}`
         storageStore.deleteFile(imagePath).catch((error) => console.log(error))
-        advertise.contentURL = ''
+        advertise.value.contentURL = ''
       }
       await advertiseStore
-        .editAdvertise(advertise)
+        .editAdvertise(advertise.value)
         .then(() => $q.notify({ type: 'info', message: 'Advertise successfully edited' }))
         .catch((error) => {
           errorStore.throwError(error, 'Advertise edit failed')
         })
         .finally(() => $q.loading.hide())
     } else {
-      const result = await createAdCampaign({ budgetInMatic: advertise.budget })
+      const result = await createAdCampaign({ budgetInMatic: advertise.value.budget })
       if (result.status.includes('success')) {
-        advertise.campaignCode = result.events[0].args.campaignCode
+        advertise.value.campaignCode = result.events[0].args.campaignCode
+        // throw new Error('')
         await advertiseStore
-          .addAdvertise(advertise)
+          .addAdvertise(advertise.value)
           .then(() => {
             $q.notify({ type: 'positive', message: 'Advertise successfully submitted' })
             emit('hideDialog')
           })
           .catch((error) => {
-            console.log(error)
+            saveDraftAd()
             errorStore.throwError(error, 'Advertise submission failed')
           })
-          .finally(() => $q.loading.hide())
-
-        if (parsedAd) {
-          LocalStorage.remove('ad')
-        }
+          .finally(() => {
+            resetAd()
+            $q.loading.hide()
+          })
       } else {
         $q.notify({ message: result?.error?.message, type: 'negative' })
-        LocalStorage.set('ad', JSON.stringify(advertise))
         $q.loading.hide()
+        await saveDraftAd()
       }
     }
     emit('hideDialog')
   } catch (error) {
     $q.notify({ message: 'Advertise submission failed', type: 'negative' })
-    errorStore.throwError(error, 'Advertise submission failed')
-    LocalStorage.set('ad', JSON.stringify(advertise))
+    await errorStore.throwError(error, 'Advertise submission failed')
+    await saveDraftAd()
     emit('hideDialog')
     $q.loading.hide()
   }
   emit('hideDialog')
 }
 
-function resetAd() {
-  LocalStorage.remove('ad')
-  parsedAd.title = ''
-  parsedAd.author = parsedAd.categories = null
-  parsedAd.date = null
-  parsedAd.content = ''
-  parsedAd.id = null
-  parsedAd.title = ''
-  parsedAd.productLink = ''
-  parsedAd.publishDate = null
-  parsedAd.type = null
-  parsedAd.duration = ''
-  parsedAd.status = ''
-  parsedAd.contentURL = ''
-  ;(advertise.budget = props.budget), (advertise.type = props.type)
+async function saveDraftAd() {
+  const adToSave = {
+    content: toRaw(advertise.value.content),
+    usdAmount: toRaw(usdAmount.value),
+    title: toRaw(advertise.value.title),
+    publishDate: toRaw(advertise.value.publishDate),
+    campaignCode: toRaw(advertise.value.campaignCode),
+    contentURL: toRaw(advertise.value.contentURL),
+    duration: toRaw(advertise.value.duration),
+    endDate: toRaw(advertise.value.endDate),
+    image: toRaw(advertise.value.image),
+    imageFile: toRaw(advertise.value.imageFile),
+    productLink: toRaw(advertise.value.productLink),
+    type: toRaw(advertise.value.type),
+    budget: toRaw(advertise.value.budget),
+    author: toRaw(advertise.value.author),
+    id: docRef.id,
+    date: currentYearMonth()
+  }
 
-  $q.notify({ type: 'info', message: 'Prompt has been reset.' })
+  if (parsedAd.value && parsedAd.value.id) {
+    await indexedDb.ad.update(parsedAd.value.id, adToSave)
+  } else {
+    await indexedDb.ad.add(adToSave)
+  }
+}
+
+function resetAd() {
+  indexedDb.ad?.clear()
+  const clearedAd = {
+    content: '',
+    usdAmount: '',
+    title: '',
+    publishDate: '',
+    campaignCode: '',
+    contentURL: '',
+    duration: '',
+    endDate: '',
+    image: null,
+    imageFile: null,
+    productLink: '',
+    type: '',
+    budget: '',
+    author: ''
+  }
+  usdAmount.value = 0
+  advertise.value = { ...clearedAd }
+  uploadedImage.value = null
+  parsedAd.value = null
+
+  nextTick(() => {
+    $q.notify({ type: 'info', message: 'Advertisement has been reset.' })
+  })
 }
 </script>

--- a/src/components/Advertiser/CampaignCard.vue
+++ b/src/components/Advertiser/CampaignCard.vue
@@ -9,7 +9,7 @@
     <q-img
       v-if="advertise.type === 'Banner'"
       class="post-image"
-      :src="advertise.type === 'Text' && !advertise.contentURl ? 'https://cdn.quasar.dev/img/parallax2.jpg' : advertise.contentURL"
+      :src="advertise.type === 'Text' && !advertise.image ? 'https://cdn.quasar.dev/img/parallax2.jpg' : advertise.image"
     />
     <div class="article-details">
       <h4 class="post-category">Advertise</h4>

--- a/src/components/Posts/ShowcaseArt.vue
+++ b/src/components/Posts/ShowcaseArt.vue
@@ -23,11 +23,11 @@
         :name="index"
         style="max-height: 450px"
       >
-        <q-img class="rounded-borders" fit="contain" :src="art" @click.stop="openDialog = true" />
+        <q-img class="rounded-borders" fit="contain" :src="art.preview ?? art" @click.stop="openDialog = true" />
       </q-carousel-slide>
-      <q-carousel-slide v-if="showcase.artist.info" class="q-pa-none" :name="showcase?.arts.length" style="max-height: 450px">
-        <q-img v-if="showcase.artist.photo" class="col-sm-6 col-xs-12 rounded-borders" :src="showcase.artist.photo" />
-        <p class="col-sm-6 col-xs-12 flex items-center q-pa-md">{{ showcase.artist.info }}</p>
+      <q-carousel-slide v-if="showcase.artist?.info" class="q-pa-none" :name="showcase?.arts.length" style="max-height: 450px">
+        <q-img v-if="showcase.artist.preview" class="col-sm-6 col-xs-12 rounded-borders" :src="showcase.artist.preview" />
+        <p class="col-sm-6 col-xs-12 flex items-center q-pa-md">{{ showcase.artist?.info }}</p>
       </q-carousel-slide>
     </q-carousel>
   </div>
@@ -46,12 +46,12 @@
       v-model="slide"
     >
       <q-carousel-slide v-for="(art, index) in showcase?.arts" class="flex justify-center q-pa-none" :key="index" :name="index">
-        <q-img class="rounded-borders" fit="contain" :src="art" />
+        <q-img class="rounded-borders" fit="contain" :src="art.preview ?? art" />
       </q-carousel-slide>
-      <q-carousel-slide v-if="showcase.artist.info" class="q-pa-none" :name="showcase?.arts.length">
-        <q-img v-if="!!showcase.artist.photo" class="col-sm-6 col-xs-12 rounded-borders" :src="showcase.artist.photo" />
+      <q-carousel-slide v-if="showcase.artist?.info" class="q-pa-none" :name="showcase?.arts.length">
+        <q-img v-if="!!showcase.artist.preview" class="col-sm-6 col-xs-12 rounded-borders" :src="showcase.artist.preview" />
         <div class="col-sm-6 col-xs-12 flex items-center q-px-xl q-py-md">
-          <p style="width: 100%; padding: 8px">{{ showcase.artist.info }}</p>
+          <p style="width: 100%; padding: 8px">{{ showcase.artist?.info }}</p>
         </div>
       </q-carousel-slide>
     </q-carousel>
@@ -61,7 +61,7 @@
 <script setup>
 import { onMounted, onUnmounted, ref } from 'vue'
 
-defineProps({
+const props = defineProps({
   showcase: { type: Object, required: true, default: () => {} }
 })
 

--- a/src/components/Posts/ThePost.vue
+++ b/src/components/Posts/ThePost.vue
@@ -18,8 +18,8 @@
           />
         </div>
       </q-responsive>
-      <div v-else-if="post.contentURL" class="bg-blur flex">
-        <q-img class="rounded-borders full-width height-auto q-mt-lg" :src="post.contentURL" />
+      <div v-else-if="post.image" class="bg-blur flex">
+        <q-img class="rounded-borders full-width height-auto q-mt-lg" :src="post.image" />
       </div>
       <q-dialog v-model="openDialog" ref="dialogRef" backdrop-filter="blur(1px)" auto-close>
         <q-img
@@ -98,7 +98,7 @@
         <q-separator v-if="!isAdd" spaced />
         <p v-if="isAdd" v-html="post?.content" class="q-mt-sm text-body1"></p>
         <p v-else class="q-mt-md text-body1" v-html="post?.description"></p>
-        <ShowcaseArt v-if="post?.showcase?.arts?.length" :showcase="post.showcase" />
+        <ShowcaseArt v-if="post?.showcase?.arts?.length || post?.showcase?.artist?.preview" :showcase="post.showcase" />
         <q-separator v-if="!isAdd" inset />
         <div class="text-center q-pt-md">
           <q-btn

--- a/src/components/shared/TheEntries.vue
+++ b/src/components/shared/TheEntries.vue
@@ -16,7 +16,7 @@
     <q-spinner v-if="entryStore.isLoading" color="primary" size="3em" class="block q-mx-auto q-my-xl" />
     <h6 v-else-if="!entries?.length" class="text-center">NO ENTRIES</h6>
   </section>
-  <q-dialog full-width position="bottom" v-model="entry.dialog" no-backdrop-dismiss no-refocus no-esc-dismiss data-test="entry-dialog">
+  <q-dialog full-width position="bottom" v-model="entry.dialog" data-test="entry-dialog">
     <EntryCard v-bind="entry" @hideDialog="entry = {}" :selectedPromptDate="promptDate" />
   </q-dialog>
 </template>

--- a/src/components/shared/TheHeader.vue
+++ b/src/components/shared/TheHeader.vue
@@ -94,7 +94,7 @@
       <PromptCard v-bind="prompt" @hideDialog="prompt = {}" />
     </q-dialog>
 
-    <q-dialog full-width position="bottom" v-model="entry.dialog" no-backdrop-dismiss no-refocus no-esc-dismiss>
+    <q-dialog full-width position="bottom" v-model="entry.dialog">
       <EntryCard v-bind="entry" @hideDialog="entry = {}" />
     </q-dialog>
 

--- a/src/pages/admin/AdminIndex.vue
+++ b/src/pages/admin/AdminIndex.vue
@@ -60,7 +60,7 @@
         <PromptCard v-bind="prompt" @hideDialog="prompt = {}" data-test="prompt-card" />
       </q-dialog>
 
-      <q-dialog full-width position="bottom" v-model="entry.dialog" no-backdrop-dismiss no-refocus no-esc-dismiss data-test="entry-dialog">
+      <q-dialog full-width position="bottom" v-model="entry.dialog" data-test="entry-dialog">
         <EntryCard v-bind="entry" @hideDialog="entry = {}" data-test="entry-card" />
       </q-dialog>
 

--- a/src/stores/advertises.js
+++ b/src/stores/advertises.js
@@ -157,8 +157,8 @@ export const useAdvertiseStore = defineStore('advertises', {
       this._isLoading = false
     },
     async addAdvertise(payload) {
+      const advertise = { ...payload }
       try {
-        const advertise = { ...payload }
         advertise.author = doc(db, 'users', advertise.author.uid)
         advertise.created = Timestamp.fromDate(new Date())
         advertise.isApproved = true
@@ -190,6 +190,11 @@ export const useAdvertiseStore = defineStore('advertises', {
         advertise.updated = Timestamp.fromDate(new Date())
         advertise.author = doc(db, 'users', advertise.author.id)
         delete advertise.categories
+        delete advertise.date
+
+        if (advertise.status === 'Published') {
+          advertise.status = 'Active'
+        }
 
         this._isLoading = true
         if (!advertise.imageFile) {

--- a/src/stores/advertises.js
+++ b/src/stores/advertises.js
@@ -24,10 +24,24 @@ import {
   useLikeStore,
   useShareStore,
   useStatStore,
+  useStorageStore,
   useUserStore,
   useVisitorStore
 } from 'src/stores'
 import { Notify } from 'quasar'
+import { convertImage } from 'src/utils/imageConvertor'
+
+async function uploadImage(image, adId) {
+  const storageStore = useStorageStore()
+  try {
+    const resizedImg = await convertImage(image)
+    const imagePath = `advertise/content-${adId}`
+    return await storageStore.uploadFile(resizedImg, imagePath)
+  } catch (error) {
+    console.error('Image upload failed:', error)
+    throw new Error('Failed to upload image')
+  }
+}
 
 export const useAdvertiseStore = defineStore('advertises', {
   state: () => ({
@@ -150,6 +164,16 @@ export const useAdvertiseStore = defineStore('advertises', {
         advertise.isApproved = true
         advertise.status = 'Active'
 
+        delete advertise.image
+        delete advertise.imagePath
+
+        if (!advertise.imageFile) {
+          delete advertise.imageFile
+        } else if (advertise.imageFile instanceof Blob) {
+          advertise.image = await uploadImage(advertise.imageFile, advertise.id)
+          delete advertise.imageFile
+        }
+
         this._isLoading = true
         await setDoc(doc(db, 'advertises', advertise.id), advertise)
         this._advertises = [advertise, ...this._advertises]
@@ -164,10 +188,17 @@ export const useAdvertiseStore = defineStore('advertises', {
       try {
         const advertise = { ...payload }
         advertise.updated = Timestamp.fromDate(new Date())
-
         advertise.author = doc(db, 'users', advertise.author.id)
+        delete advertise.categories
 
         this._isLoading = true
+        if (!advertise.imageFile) {
+          delete advertise.imageFile
+        } else if (advertise.imageFile instanceof Blob) {
+          advertise.image = await uploadImage(advertise.imageFile, advertise.id)
+          delete advertise.imageFile
+        }
+
         await runTransaction(db, async (transaction) => {
           transaction.update(doc(db, 'advertises', advertise.id), advertise)
         })

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -312,16 +312,29 @@ export const useEntryStore = defineStore('entries', {
       this._isLoading = true
       const promptStore = usePromptStore()
       const entry = { ...payload }
+      const artsToRemove = entry.artsToRemove
       entry.author = doc(db, 'users', entry.author.value)
       entry.prompt = promptStore.getPromptRef(entry.prompt.value)
       entry.updated = Timestamp.fromDate(new Date())
+
       delete entry.imagePreview
       delete entry.selectedPromptDate
+      delete entry.isNavigatingFromPrompt
+
+      if (artsToRemove?.length) {
+        for (const art of artsToRemove) {
+          const imageRef = ref(storage, art)
+          await deleteObject(imageRef)
+        }
+        delete entry.artsToRemove
+      } else {
+        delete entry.artsToRemove
+      }
 
       if (!entry.imageFile) {
         delete entry.imageFile
       } else if (entry.imageFile instanceof Blob) {
-        entry.image = await uploadImage(entry.imageFile, entry.id)
+        entry.image = await uploadImage(entry.imageFile, `entry-${entry.id}`)
         delete entry.imageFile
       }
 
@@ -343,6 +356,14 @@ export const useEntryStore = defineStore('entries', {
           this._isLoading = false
           throw new Error('Failed to upload image')
         }
+      }
+
+      if (!entry.showcase?.artist.file) {
+        delete entry.imageFile
+      } else if (entry.showcase?.artist.file instanceof Blob) {
+        entry.showcase.artist.preview = await uploadImage(entry.showcase.artist.file, `artist-${entry.id}`)
+        delete entry.showcase.artist.file
+        delete entry.showcase.artist.photo
       }
 
       await runTransaction(db, async (transaction) => {
@@ -382,7 +403,9 @@ export const useEntryStore = defineStore('entries', {
       }
     },
 
-    async deleteEntry(entryId, arts) {
+    async deleteEntry(entry) {
+      let entryData
+      const entryRef = entry.length ? doc(db, 'entries', entry) : doc(db, 'entries', entry.id)
       const commentStore = useCommentStore()
       const errorStore = useErrorStore()
       const likeStore = useLikeStore()
@@ -390,8 +413,20 @@ export const useEntryStore = defineStore('entries', {
       const visitorStore = useVisitorStore()
       const statStore = useStatStore()
 
-      const promptId = entryId.split('T')[0]
-      const entryRef = doc(db, 'entries', entryId)
+      // If "entry" is an id, get the entry reference
+      if (entry.length) {
+        if (entryRef) {
+          const entryDoc = await getDoc(entryRef)
+          entryData = entryDoc.data()
+        }
+      } else {
+        entryData = entry
+      }
+
+      const promptId = entryData.prompt?.id.split('T')[0]
+      const entryId = entryData.id
+      const arts = entryData.showcase?.arts
+      const artistImage = entryData.showcase?.artist.preview
 
       this._isLoading = true
 
@@ -416,12 +451,20 @@ export const useEntryStore = defineStore('entries', {
           deleteEntryFromStats
         ])
 
-        if (arts) {
+        if (arts && arts.length) {
           for (const art of arts) {
-            const imgId = art.match(/entry-[^?\/]+/)
-            await deleteObject(ref(storage, `images/${imgId}`))
+            if (art.preview?.length) {
+              const imageRef = ref(storage, art.preview)
+              await deleteObject(imageRef)
+            }
           }
         }
+
+        if (artistImage?.length) {
+          const imageRef = ref(storage, artistImage)
+          await deleteObject(imageRef)
+        }
+
         this._entries = this._entries?.filter((entry) => entry.id !== entryId)
       } catch (error) {
         await errorStore.throwError(error, 'Error deleting entry')

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -239,6 +239,7 @@ export const useEntryStore = defineStore('entries', {
     },
 
     async addEntry(payload) {
+      console.log(payload)
       const notificationStore = useNotificationStore()
       const promptStore = usePromptStore()
 

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -239,7 +239,6 @@ export const useEntryStore = defineStore('entries', {
     },
 
     async addEntry(payload) {
-      console.log(payload)
       const notificationStore = useNotificationStore()
       const promptStore = usePromptStore()
 

--- a/src/stores/entries.js
+++ b/src/stores/entries.js
@@ -1,7 +1,6 @@
 import {
   arrayRemove,
   arrayUnion,
-  and,
   collection,
   deleteDoc,
   doc,
@@ -32,6 +31,8 @@ import {
   useUserStore,
   useVisitorStore
 } from 'src/stores'
+import { uploadImage } from 'src/utils/helpers'
+import { uid } from 'quasar'
 
 function snapshotDocs(querySnapshot) {
   const entries = []
@@ -239,51 +240,117 @@ export const useEntryStore = defineStore('entries', {
     },
 
     async addEntry(payload) {
+      this._isLoading = true
       const notificationStore = useNotificationStore()
       const promptStore = usePromptStore()
-
       const entry = { ...payload }
 
       const promptId = entry.prompt.value
       const escrowId = entry.prompt.escrowId
       const entryRef = doc(db, 'entries', entry.id)
-
       entry.author = doc(db, 'users', entry.author.value)
       entry.created = Timestamp.fromDate(new Date())
       entry.prompt = promptStore.getPromptRef(entry.prompt.value)
       entry.escrowId = escrowId || null
 
-      this._isLoading = true
-      await setDoc(entryRef, entry).finally(() => (this._isLoading = false))
+      delete entry.image
+      delete entry.imagePath
 
-      await updateDoc(doc(db, 'prompts', promptId), { entries: arrayUnion(entryRef) })
+      if (!entry.imageFile) {
+        delete entry.imageFile
+      } else if (entry.imageFile instanceof Blob) {
+        entry.image = await uploadImage(entry.imageFile, `entry-${entry.id}`)
+        delete entry.imageFile
+      }
+      if (!entry.showcase?.artist.file) {
+        delete entry.imageFile
+      } else if (entry.showcase?.artist.file instanceof Blob) {
+        entry.showcase.artist.preview = await uploadImage(entry.showcase.artist.file, `artist-${entry.id}`)
+        delete entry.showcase.artist.file
+        delete entry.showcase.artist.photo
+      }
 
-      await notificationStore.toggleSubscription('entries', entry.id)
+      if (entry.showcase?.arts?.length > 0) {
+        try {
+          const uploadedArts = []
+          for (const art of entry.showcase.arts) {
+            if (art.file instanceof Blob) {
+              const imagePath = `arts/arts-${uid()}`
+              const downloadUrl = await uploadImage(art.file, imagePath)
+              uploadedArts.push({ preview: downloadUrl })
+            } else {
+              uploadedArts.push({ preview: art.url || '' })
+            }
+          }
+          entry.showcase.arts = uploadedArts
+        } catch (error) {
+          console.error('Image upload failed:', error)
+          this._isLoading = false
+          throw new Error('Failed to upload image')
+        }
+      }
+
+      try {
+        await setDoc(entryRef, entry)
+        await updateDoc(doc(db, 'prompts', promptId), { entries: arrayUnion(entryRef) })
+        await notificationStore.toggleSubscription('entries', entry.id)
+      } catch (error) {
+        console.error('Failed to add entry:', error)
+        throw error
+      } finally {
+        this._isLoading = false
+      }
     },
 
     async editEntry(payload) {
+      this._isLoading = true
       const promptStore = usePromptStore()
-
       const entry = { ...payload }
-
       entry.author = doc(db, 'users', entry.author.value)
       entry.prompt = promptStore.getPromptRef(entry.prompt.value)
       entry.updated = Timestamp.fromDate(new Date())
+      delete entry.imagePreview
+      delete entry.selectedPromptDate
 
-      this._isLoading = true
+      if (!entry.imageFile) {
+        delete entry.imageFile
+      } else if (entry.imageFile instanceof Blob) {
+        entry.image = await uploadImage(entry.imageFile, entry.id)
+        delete entry.imageFile
+      }
+
+      if (entry.showcase?.arts?.length > 0) {
+        try {
+          const uploadedArts = []
+          for (const art of entry.showcase.arts) {
+            if (art.file instanceof Blob) {
+              const imagePath = `arts/arts-${uid()}`
+              const downloadUrl = await uploadImage(art.file, imagePath)
+              uploadedArts.push({ preview: downloadUrl })
+            } else {
+              uploadedArts.push({ preview: art.preview || '' })
+            }
+          }
+          entry.showcase.arts = uploadedArts
+        } catch (error) {
+          console.error('Image upload failed:', error)
+          this._isLoading = false
+          throw new Error('Failed to upload image')
+        }
+      }
+
       await runTransaction(db, async (transaction) => {
         transaction.update(doc(db, 'entries', entry.id), { ...entry })
       })
-      this._isLoading = false
       const prompt = promptStore.getPromptRef(entry.prompt?.id)
       const updatedEntryDoc = await getDoc(doc(db, 'entries', entry.id))
       const updatedPromptDoc = await getDoc(doc(db, 'prompts', prompt.id))
 
+      this._isLoading = false
       return {
         _entry: updatedEntryDoc.data(),
         _prompt: updatedPromptDoc.data()
       }
-      //}).finally(() => (this._isLoading = false))
     },
 
     //update not coming from form submission

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -370,9 +370,19 @@ export const usePromptStore = defineStore('prompts', {
     async editPrompt(payload) {
       const prompt = { ...payload }
       const userStore = useUserStore()
-
+      const artsToRemove = prompt.artsToRemove
       prompt.author = doc(db, 'users', prompt.author.value)
       prompt.updated = Timestamp.fromDate(new Date())
+
+      if (artsToRemove?.length) {
+        for (const art of artsToRemove) {
+          const imageRef = ref(storage, art)
+          await deleteObject(imageRef)
+        }
+        delete prompt.artsToRemove
+      } else {
+        delete prompt.artsToRemove
+      }
 
       if (!prompt.imageFile) {
         delete prompt.imageFile
@@ -401,6 +411,13 @@ export const usePromptStore = defineStore('prompts', {
           this._isLoading = false
           throw new Error('Failed to upload image')
         }
+      }
+      if (!prompt.showcase?.artist.file) {
+        delete prompt.imageFile
+      } else if (prompt.showcase?.artist.file instanceof Blob) {
+        prompt.showcase.artist.preview = await uploadImage(prompt.showcase.artist.file, `artist-${prompt.id}`)
+        delete prompt.showcase.artist.file
+        delete prompt.showcase.artist.photo
       }
 
       delete prompt.date
@@ -459,7 +476,8 @@ export const usePromptStore = defineStore('prompts', {
       }
     },
 
-    async deletePrompt(id) {
+    async deletePrompt(prompt) {
+      const id = prompt.id
       const commentStore = useCommentStore()
       const entryStore = useEntryStore()
       const errorStore = useErrorStore()
@@ -467,27 +485,55 @@ export const usePromptStore = defineStore('prompts', {
       const shareStore = useShareStore()
       const visitorStore = useVisitorStore()
       const statStore = useStatStore()
-
+      const artsToRemove = prompt.showcase?.arts
+      const artistImage = prompt.showcase?.artist?.preview
       const relatedEntries = this._prompts.find((prompt) => prompt.id === id)?.entries || []
-
       this._isLoading = true
-      if (relatedEntries.length) {
-        for (const entryId of relatedEntries) {
-          await entryStore.deleteEntry(entryId)
-        }
-      }
+
+      const promptRef = doc(db, 'prompts', id)
+      const promptSnapshot = await getDoc(promptRef)
 
       try {
-        const deleteImage = deleteObject(ref(storage, `images/prompt-${id}`))
-        const deleteComments = commentStore.deleteCommentsCollection('prompts', id)
-        const deleteLikes = likeStore.deleteAllLikesDislikes('prompts', id)
-        const deletePromptDoc = deleteDoc(doc(db, 'prompts', id))
-        const deleteShares = shareStore.deleteAllShares('prompts', id)
-        const deleteVisitors = visitorStore.deleteAllVisitors('prompts', id)
-        const deletePromptFromStats = statStore.removeTopic(id)
+        await Promise.all([
+          deleteObject(ref(storage, `images/prompt-${id}`)).catch((err) => {
+            console.warn(`Failed to delete image for prompt ${id}:`, err)
+            return null
+          }),
+          commentStore.deleteCommentsCollection('prompts', id),
+          likeStore.deleteAllLikesDislikes('prompts', id),
+          shareStore.deleteAllShares('prompts', id),
+          visitorStore.deleteAllVisitors('prompts', id),
+          statStore.removeTopic(id)
+        ])
 
-        await Promise.all([deleteComments, deleteImage, deleteLikes, deleteShares, deletePromptDoc, deleteVisitors, deletePromptFromStats])
+        if (relatedEntries.length) {
+          for (const entryId of relatedEntries) {
+            await entryStore.deleteEntry(entryId)
+          }
+        }
+
+        if (promptSnapshot.exists()) {
+          await deleteDoc(promptRef)
+          console.log(`Document ${id} deleted successfully`)
+        } else {
+          console.log(`Document ${id} does not exist, skipping deletion`)
+        }
+
         this._prompts = this.getPrompts?.filter((prompt) => prompt.id !== id)
+
+        if (artsToRemove.length > 0) {
+          for (const art of artsToRemove) {
+            if (art.preview?.length) {
+              const url = art.preview ? art.preview : art
+              const imageRef = ref(storage, url)
+              await deleteObject(imageRef)
+            }
+          }
+        }
+        if (artistImage?.length) {
+          const imageRef = ref(storage, artistImage)
+          await deleteObject(imageRef)
+        }
       } catch (error) {
         await errorStore.throwError(error, 'Error deleting prompt')
       }

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -301,8 +301,6 @@ export const usePromptStore = defineStore('prompts', {
     },
 
     async addPrompt(payload) {
-      console.log(payload)
-
       const notificationStore = useNotificationStore()
       const userStore = useUserStore()
       const isTester = payload.author.label === 'Cypress Tester'

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -301,6 +301,8 @@ export const usePromptStore = defineStore('prompts', {
     },
 
     async addPrompt(payload) {
+      console.log(payload)
+
       const notificationStore = useNotificationStore()
       const userStore = useUserStore()
       const isTester = payload.author.label === 'Cypress Tester'

--- a/src/stores/prompts.js
+++ b/src/stores/prompts.js
@@ -30,8 +30,10 @@ import {
   useUserStore,
   useVisitorStore
 } from 'src/stores'
-import { Notify } from 'quasar'
+import { Notify, uid } from 'quasar'
 import { currentYearMonth } from 'src/utils/date'
+import { uploadImage } from 'src/utils/helpers'
+import { convertImage } from 'src/utils/imageConvertor'
 
 let updatedBefore = false
 const getPrompts = async (querySnapshot, userStore) => {
@@ -301,23 +303,68 @@ export const usePromptStore = defineStore('prompts', {
     },
 
     async addPrompt(payload) {
+      this._isLoading = true
+      const collectionRef = collection(db, 'prompts')
+      const docRef = doc(collectionRef)
       const notificationStore = useNotificationStore()
       const userStore = useUserStore()
-      const isTester = payload.author.label === 'Cypress Tester'
-      const prompt = isTester ? { ...payload, escrowId: '0.0000000000000000001' } : { ...payload }
-      prompt.author = doc(db, 'users', prompt.author.value)
+      const isTester = payload.value.author?.label === 'Cypress Tester'
+      const prompt = isTester ? { ...payload.value, escrowId: '0.0000000000000000001' } : { ...payload.value }
+
+      prompt.author = doc(db, 'users', prompt.author?.value)
       prompt.created = Timestamp.fromDate(new Date())
-      prompt.id = payload.id
+      prompt.id = docRef.id
       prompt.hasWinner = null
 
-      this._isLoading = true
-      await setDoc(doc(db, 'prompts', prompt.id), prompt).finally(() => (this._isLoading = false))
+      delete prompt.image
+      delete prompt.imagePath
+      delete prompt.showcase.imageFiles
 
+      //PROMPT IMAGE
+      if (!prompt.imageFile) {
+        delete prompt.imageFile
+      } else if (prompt.imageFile instanceof Blob) {
+        prompt.image = await uploadImage(prompt.imageFile, `prompt-${prompt.id}`)
+        delete prompt.imageFile
+      }
+      //AUTHOR IMAGE
+
+      if (!prompt.showcase?.artist.file) {
+        delete prompt.imageFile
+      } else if (prompt.showcase?.artist.file instanceof Blob) {
+        prompt.showcase.artist.preview = await uploadImage(prompt.showcase.artist.file, `artist-${prompt.id}`)
+        delete prompt.showcase.artist.file
+        delete prompt.showcase.artist.photo
+      }
+
+      //ARTS IMAGE
+
+      if (prompt.showcase?.arts?.length > 0) {
+        try {
+          const uploadedArts = []
+          for (const art of prompt.showcase.arts) {
+            if (art.file instanceof Blob) {
+              const imagePath = `arts/arts-${uid()}`
+              const downloadUrl = await uploadImage(art.file, imagePath)
+              uploadedArts.push({ preview: downloadUrl })
+            } else {
+              uploadedArts.push({ preview: art.url || '' })
+            }
+          }
+          prompt.showcase.arts = uploadedArts
+        } catch (error) {
+          console.error('Image upload failed:', error)
+          this._isLoading = false
+          throw new Error('Failed to upload image')
+        }
+      }
+
+      await setDoc(doc(db, 'prompts', prompt.id), prompt)
       prompt.author = await userStore.fetchUser(prompt.author.id)
       prompt.entries = []
       this._prompts = this.getPrompts ? [prompt, ...this.getPrompts] : [prompt]
-
       await notificationStore.toggleSubscription('prompts', prompt.id)
+      this._isLoading = false
     },
 
     async editPrompt(payload) {
@@ -326,6 +373,37 @@ export const usePromptStore = defineStore('prompts', {
 
       prompt.author = doc(db, 'users', prompt.author.value)
       prompt.updated = Timestamp.fromDate(new Date())
+
+      if (!prompt.imageFile) {
+        delete prompt.imageFile
+        delete prompt.imagePreview
+      } else if (prompt.imageFile instanceof Blob) {
+        prompt.image = await uploadImage(prompt.imageFile, `prompt-${prompt.id}`)
+        delete prompt.imageFile
+        delete prompt.imagePreview
+      }
+
+      if (prompt.showcase?.arts?.length > 0) {
+        try {
+          const uploadedArts = []
+          for (const art of prompt.showcase.arts) {
+            if (art.file instanceof Blob) {
+              const imagePath = `arts/arts-${uid()}`
+              const downloadUrl = await uploadImage(art.file, imagePath)
+              uploadedArts.push({ preview: downloadUrl })
+            } else {
+              uploadedArts.push({ preview: art.preview || '' })
+            }
+          }
+          prompt.showcase.arts = uploadedArts
+        } catch (error) {
+          console.error('Image upload failed:', error)
+          this._isLoading = false
+          throw new Error('Failed to upload image')
+        }
+      }
+
+      delete prompt.date
 
       this._isLoading = true
       await runTransaction(db, async (transaction) => {

--- a/src/stores/storage.js
+++ b/src/stores/storage.js
@@ -15,10 +15,11 @@ export const useStorageStore = defineStore('storage', {
     async uploadFile(file, filePathAndName) {
       const storageRef = ref(storage, filePathAndName)
 
-      this._isLoading = true
-      await uploadBytes(storageRef, file).finally(() => (this._isLoading = false))
-
-      return getDownloadURL(storageRef).then((url) => url)
+      // this._isLoading = true
+      await uploadBytes(storageRef, file)
+      // .finally(() => (this._isLoading = false))
+      const url = getDownloadURL(storageRef).then((url) => url)
+      return url
     },
 
     async deleteFile(filePathAndName) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,44 @@
+import { useStorageStore } from 'src/stores'
+import { convertImage } from 'src/utils/imageConvertor'
+
+export function onPaste(event, editorRef) {
+  if (event.target.nodeName === 'INPUT') return
+
+  let text
+  let onPasteStripFormattingIEPaste = false
+
+  event.preventDefault()
+  event.stopPropagation()
+
+  if (!editorRef || !editorRef.value) {
+    console.warn('Editor reference is not available yet.')
+    return
+  }
+
+  if (event.originalEvent && event.originalEvent.clipboardData?.getData) {
+    text = event.originalEvent.clipboardData.getData('text/plain')
+    editorRef.value.runCmd('insertText', text)
+  } else if (event.clipboardData?.getData) {
+    text = event.clipboardData.getData('text/plain')
+    editorRef.value.runCmd('insertText', text)
+  } else if (window.clipboardData?.getData) {
+    if (!onPasteStripFormattingIEPaste) {
+      onPasteStripFormattingIEPaste = true
+      text = window.clipboardData.getData('text')
+      editorRef.value.runCmd('ms-pasteTextOnly', text)
+    }
+    onPasteStripFormattingIEPaste = false
+  }
+}
+
+export async function uploadImage(image, imagePath) {
+  const storageStore = useStorageStore()
+  try {
+    const resizedImg = await convertImage(image)
+    const fullPath = `images/${imagePath}`
+    return await storageStore.uploadFile(resizedImg, fullPath)
+  } catch (error) {
+    console.error('Image upload failed:', error)
+    throw new Error('Failed to upload image')
+  }
+}

--- a/src/utils/imageConvertor.js
+++ b/src/utils/imageConvertor.js
@@ -1,10 +1,5 @@
-import { useStorageStore, useErrorStore } from 'src/stores'
-
-export async function uploadAndSetImage(imageFile, filePathAndName) {
-  const storageStore = useStorageStore()
-  const errorStore = useErrorStore()
+export async function convertImage(imageFile) {
   return new Promise((resolve, reject) => {
-    // Validate imageFile
     if (!(imageFile instanceof Blob)) {
       const errorMessage = 'Invalid file type. Expected a Blob or File.'
       console.error(errorMessage, imageFile)
@@ -12,12 +7,10 @@ export async function uploadAndSetImage(imageFile, filePathAndName) {
     }
 
     const reader = new FileReader()
-
-    reader.onload = async (event) => {
+    reader.onload = (event) => {
       const imageDataURL = event?.target?.result
       const img = new Image()
-
-      img.onload = async () => {
+      img.onload = () => {
         const MAX_WIDTH = 2560
         const MAX_HEIGHT = 1440
         let width = img.width
@@ -36,20 +29,30 @@ export async function uploadAndSetImage(imageFile, filePathAndName) {
         const ctx = canvas.getContext('2d')
         canvas.width = width
         canvas.height = height
-
         ctx.drawImage(img, 0, 0, width, height)
 
-        canvas.toBlob(async (blob) => {
-          try {
-            const imageUrl = await storageStore.uploadFile(blob, filePathAndName)
-            resolve(imageUrl)
-          } catch (error) {
-            await errorStore.throwError(error, 'Image upload failed')
-            reject(error)
-          }
-        }, 'image/webp')
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              resolve(blob)
+            } else {
+              reject(new Error('Failed to create Blob from canvas'))
+            }
+          },
+          'image/webp',
+          0.95
+        )
       }
+
+      img.onerror = () => {
+        reject(new Error('Failed to load image for resizing'))
+      }
+
       img.src = imageDataURL
+    }
+
+    reader.onerror = () => {
+      reject(new Error('Failed to read image file'))
     }
 
     reader.readAsDataURL(imageFile)

--- a/src/utils/indexeddb.js
+++ b/src/utils/indexeddb.js
@@ -1,0 +1,10 @@
+import Dexie from 'dexie'
+
+export const indexedDb = new Dexie('myDatabase')
+
+indexedDb.version(1).stores({
+  entry: '++id, author, description, id, image, imageFile, imagePath, prompt, showcase, slug, title',
+  prompt:
+    '++id, author, description, image, imageFile, showcase, slug, title, publicationDate, endDate, categories, creationDate, paymentStatus, rewardAmount, imagePath',
+  ad: '++id, budget, campaignCode, contentURL, id, endDate, content, image, imageFile, title, productLink, publishDate, type, duration, usdAmount'
+})


### PR DESCRIPTION
### 🛠 Description
Fixes #719 

This PR implements saving of Prompts, Entries or Advertisements in case submission process fails and creation modal closes. A draft copy is being saved to local storage and on next try fields are populated automatically with offering user the option to reset the fields and start over. 

This also implements automatic image removal from DB in case creation process fails. 

To note that images are not being saved in local storage as drafts. 

### ✨ Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🧪 All Test Suites Passed?

- [X] Manual tested
- [ ] Cypress
