### PR TITLE
fix:#728 - Prevent Creation of Entries for Other Prompts from Prompt Page

### DIFF
--- a/src/components/Admin/EntryCard.vue
+++ b/src/components/Admin/EntryCard.vue
@@ -12,7 +12,7 @@
           behavior="menu"
           counter
           data-test="select-prompt"
-          :disable="Boolean(entry.id)"
+          :disable="Boolean(entry.id) || isNavigatingFromPrompt"
           :hint="entry.image ? 'Image is attached to this prompt' : ''"
           label="Prompt"
           :options="promptOptions"
@@ -150,13 +150,24 @@
 <script setup>
 import { useQuasar } from 'quasar'
 import { useEntryStore, useErrorStore, usePromptStore, useStorageStore, useUserStore } from 'src/stores'
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watchEffect } from 'vue'
 import { uploadAndSetImage } from 'src/utils/imageConvertor'
 import { useRouter } from 'vue-router'
 import CaptureCamera from '../shared/CameraCapture.vue'
 
 const emit = defineEmits(['hideDialog'])
-const props = defineProps(['author', 'created', 'description', 'id', 'image', 'prompt', 'slug', 'title', 'selectedPromptDate'])
+const props = defineProps([
+  'author',
+  'created',
+  'description',
+  'id',
+  'image',
+  'prompt',
+  'slug',
+  'title',
+  'selectedPromptDate',
+  'isNavigatingFromPrompt'
+])
 
 const $q = useQuasar()
 const entryStore = useEntryStore()
@@ -197,8 +208,15 @@ onMounted(() => {
     entry.image = props.image
     entry.prompt = { label: `${props.prompt.date || props.prompt.publicationDate} – ${props.prompt.title}`, value: props.prompt.id }
     entry.title = props.title
-  } else if (props.selectedPromptDate) {
-    entry.prompt = promptOptions.value.find((prompt) => prompt.value === props.selectedPromptDate)
+  }
+})
+
+watchEffect(() => {
+  if (props.isNavigatingFromPrompt && props.selectedPromptDate && promptOptions.value.length && !entry.prompt) {
+    const selectedPrompt = promptOptions.value.find((prompt) => prompt.value === props.selectedPromptDate)
+    if (selectedPrompt) {
+      entry.prompt = selectedPrompt
+    }
   }
 })
 

--- a/src/components/shared/TheEntries.vue
+++ b/src/components/shared/TheEntries.vue
@@ -17,7 +17,7 @@
     <h6 v-else-if="!entries?.length" class="text-center">NO ENTRIES</h6>
   </section>
   <q-dialog full-width position="bottom" v-model="entry.dialog" no-backdrop-dismiss no-refocus no-esc-dismiss data-test="entry-dialog">
-    <EntryCard v-bind="entry" @hideDialog="entry = {}" :selectedPromptDate="promptDate" />
+    <EntryCard v-bind="entry" @hideDialog="entry = {}" :selectedPromptDate="props.promptDate" :isNavigatingFromPrompt="true" />
   </q-dialog>
 </template>
 


### PR DESCRIPTION
### 🛠 Description

When a user wants to add an entry directly to a prompt page, the prompt drop down restricted so that they can't create for another prompt.
#### Changes Made

- check Entry Crud is Navigating From Prompt page 
- Updated prompt drop-down functionality selections to the current prompt.
- Added restrict to prevent selecting other prompts.(disable)

How to Test
- Go to the active prompt page.
- Try adding an entry and check the prompt drop-down.

Fixes #728 

### ✨ Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧠 Rationale behind the change

Why did you choose to make these changes? Were there any trade-offs you had to consider?

### 🧪 All Test Suites Passed?

- [x] Manual tested
- [ ] Cypress

### 📸 Screenshots (optional)

Please provide some screenshot for relevant changes

### 🏎 Quick checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
